### PR TITLE
Revamp parser documentation and add summary of parser violations

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ Translates the SplashKit C++ source into another language.
 - [SplashKit Translator](#splashkit-translator)
 - [Contents](#contents)
 - [Running](#running)
+   - [Dependencies](#dependencies)
+   - [Validating](#validating)
+   - [Converting](#converting)
 - [SplashKit Documentation Guidelines](#splashkit-documentation-guidelines)
    - [Header File Docblocks](#header-file-docblocks)
    - [Function Docblocks](#function-docblocks)
@@ -19,11 +22,15 @@ Translates the SplashKit C++ source into another language.
       - [`class`](#class)
          - [Usage in typedefs](#usage-in-typedefs)
          - [Usage in functions](#usage-in-functions)
+      - [`static`](#static)
       - [`method`](#method)
       - [`constructor`](#constructor)
       - [`destructor`](#destructor)
       - [`self`](#self)
       - [`suffix`](#suffix)
+      - [`getter`](#getter)
+      - [`setter`](#setter)
+   - [Summary Rules](#summary-rules)
 
 <!-- /MDTOC -->
 
@@ -234,6 +241,7 @@ When added to a typedef, the type will be declared as a class:
 typedef struct _sound_data *sound_effect;
 ```
 
+<p id="pr16-class"/>
 Note that typedef aliases to pointers **must** be declared with a `class` attribute.
 
 #### Usage in functions
@@ -276,16 +284,23 @@ Associates a function to a class. Requires the `class` or `static` attribute to
 be set. The name specified by `method` will be the method name that will be used
 as the method on the class. See the above example.
 
+<p id="pr2-instance-method"/>
 When `method` is used with the `class` attribute, an _instance method_ will be
 generated on the class whose name is specified by `class`.
 
+<p id="pr2-static-method"/>
 When `method` is used with the `static` attribute, a _static method_ will be
 generated on the class whose name is specified by `static`.
 
 ### `constructor`
 
-Associates a function as the constructor to a class. Requires the `class`
-attribute to be set. To mark a constructor, simply set the value as `true`:
+Associates a function as the constructor to a class.
+
+<p id="pr1-constructor"/>
+Requires the `class` attribute to be set in order to construct an _instance_
+of that class.
+
+To mark a constructor, simply set the value as `true`:
 
 ```c
 /**
@@ -303,10 +318,28 @@ This will convert the above to an equivalent OO constructor:
 SoundEffect(string name, string filename)
 ```
 
+<p id="pr3-constructor"/>
+If defining a `constructor`, then you cannot violate this attribute with a
+`destructor` attribute in the same HeaderDoc block.
+
+<p id="pr4-constructor"/>
+<p id="pr5-destructor"/>
+Unless `static` is specified, then a `destructor` function cannot _also_ act as
+a instance `getter`, `setter` or `method`.
+
 ### `destructor`
 
-Same as `constructor`, but for a destructor. Requires a `self` attribute to be
-set (see below).
+Same as `constructor`, but for a destructor.
+
+<p id="pr1-destructor"/>
+Requires the `class` attribute to be set in order to destruct an _instance_
+of that class.
+
+Similarly, to destruct a particular instance, the instance object will be
+passed into the parameter specified by a `self` attribute. Thus `self` must
+be set on `destructor`s.
+
+For example:
 
 ```c
 /**
@@ -326,12 +359,32 @@ the `effect` parameter:
 delete someSoundEffectInstance;
 ```
 
+<p id="pr3-destructor"/>
+If defining a `destructor`, then you cannot violate this attribute with a
+`constructor` attribute in the same HeaderDoc block.
+
+<p id="pr4-destructor"/>
+<p id="pr5-destructor"/>
+Unless `static` is specified, then a `destructor` function cannot _also_ act as
+an instance `getter`, `setter` or `method`.
+
 ### `self`
 
 Specifies the name of the parameter which should act as `this` or `self` on the
-function call. That is, when the function is converted to a method for an OO
-language, the instance calling the method will be passed into the parameter
-specified by `self`. For example:
+function call.
+
+<p id="pr1-self"/>
+When the function is converted to a method for an object-oriented language,
+the instance calling the method will be passed into parameter specified by
+`self`.
+
+<p id="pr7-self"/>
+<p id="pr8-self"/>
+To know which type the `self` parameter would be, list the `class` of that
+parameter and make sure it matches the name of the parameter indicated by
+`self`.
+
+For example:
 
 ```c
 /**
@@ -376,8 +429,18 @@ void play_sound_effect(sound_effect effect, int times, float volume);
 
 For translated languages that do not support overloaded function names, the
 name specified by `suffix` name will be used as a suffix appended to the global
-and instance name of the function/method. Suffix + method name must be unique
-within the class, suffix + function name must be unique globally.
+and instance name of the function.
+
+<p id="pr15-suffix"/>
+If `class` is specified, then the `method` name appended with `suffix` must be
+unique _within that `class`_.
+
+If `static` is specified, then function name appended with `suffix` must be
+unique _within that `static` namespace_.
+
+<p id="pr14-suffix"/>
+If neither are specified, then function name appended with `suffix` must be
+unique _globally_.
 
 For example:
 
@@ -410,7 +473,12 @@ Audio.PlaySoundEffect(effect, 3, 10.0f)
 
 ### `getter`
 
-Creates a getter method to the `class` specified. Requires either:
+Creates a getter method to the `class` or `static` module specified. Requires
+either:
+
+<p id="pr2-instance-getter"/>
+<p id="pr4-instance-getter"/>
+<p id="pr2-static-getter"/>
 
 * `class` and `self` to make an _instance_ getter on the an instance whose class
    is specified by `class`, or
@@ -418,14 +486,20 @@ Creates a getter method to the `class` specified. Requires either:
 
 Must be set on a function that:
 
+<p id="pr9-getter"/>
 * has __exactly__ _zero_ or _one_ parameters, depending on if you are using
   `class` or `static`, and
 * is non-void.
 
+<p id="pr12-getter"/>
 If you are writing a __`static`__ getter, then there must be no parameters.
 
+<p id="pr6-getter"/>
+<p id="pr10-getter"/>
 If you are writing a __`class`__ setter, then you will need __exactly _one_
-parameter__, that being the parameter which will be used as `self`.
+parameter__, that being the parameter which will be used as `self`. You must
+not specify that the function also a `method` (unless `static` is also supplied)
+or a `constructor` or `destructor`.
 
 For example, the following:
 
@@ -457,7 +531,12 @@ if (myDatabase.queryResult.IsEmpty) { ... };
 
 ### `setter`
 
-Creates a setter method. Requires either:
+Creates a setter method on the `class` instance of `static` module. Requires
+either:
+
+<p id="pr2-instance-setter"/>
+<p id="pr4-instance-setter"/>
+<p id="pr2-static-setter"/>
 
 * `class` and `self` to make an _instance_ setter on the an instance whose class
    is specified by `class`, or
@@ -467,14 +546,20 @@ Creates a setter method. Requires either:
 Must be set on a function that has __exactly__ _one_ or _two_ parameters, which
 depends on if you are using `class` or `static`.
 
+<p id="pr13-setter"/>
 If you are writing a __`static`__ setter, then you will need __exactly one
 parameter__, being the the second must the value that is to be set.
 
+<p id="pr11-setter"/>
 If you are writing a __`class`__ setter, then you will need __exactly _two_
 parameters__, where:
 
 1. the first must be the the parameter which will be used as `self`, and
 2. the second must the value that is to be set.
+
+<p id="pr6-setter"/>
+You must not specify that this is also a `method` (unless `static` is also
+supplied) or a `constructor` or `destructor`.
 
 For example, the following:
 
@@ -503,3 +588,76 @@ generates usage for the following in C#:
 Audio.IsOpen = false;
 myDatabase.LastQuery = myQueryResult;
 ```
+
+## Summary of Parser Rules
+
+If any of these basic rules are violated, then the parser will throw a fatal
+error and stop parsing along with its respective parser rule (PR) number
+for reference to this list.
+
+1. <p id="rule-1"/>
+   Attributes marked with [`self`](#pr1-self), [`destructor`](#pr1-destructor)
+   [`constructor`](#pr1-constructor) must have a `class` attribute specified.
+2. <p id="rule-2"/>
+   Attributes marked with `method`, `getter` or `setter` must be marked with
+   either:
+
+    (i) **`class`** to make it an [instance method](#pr2-instance-method), [instance getter](#pr2-instance-getter) or [instance setter](#pr2-instance-setter) on _instance_ of that class, or
+
+    (ii) **`static`** to make it a [static method](#pr2-static-method), [static getter](#pr2-static-getter) or [static setter](#pr2-static-setter) on a class or module indicated by static.
+
+3. <p id="rule-3"/>
+   There can never be both [`constructor`](#pr3-constructor) and
+   [`destructor`](#pr3-destructor) attributes marked together in the same
+   HeaderDoc block.
+4. <p id="rule-4"/>
+   If you do not supply `static`, then you cannot have a
+   [`constructor`](#pr4-constructor) or [`destructor`](#pr4-destructor) with
+   a `getter` or `setter` in the same block. This would imply that there is an
+   [instance getter](#pr4-instance-getter) or
+   [instance setter](#pr4-instance-setter) along with a constructor or
+   destructor of that instance by the _one_ function.
+5. <p id="rule-5"/>
+   You cannot supply [`constructor`](#pr5-constructor) or
+   [`destructor`](#pr5-destructor)  and `method` unless
+   `static` is also supplied. This will make a static method on
+   the class or module specified by static but a destructor/constructor on
+   the class indicated by `class`.
+6. <p id="rule-6"/>
+   Same as above, except for [`getter`](#pr6-getter)s and
+   [`setter`](#pr6-setter)s.
+7. <p id="rule-7"/>
+   A `self` attribute [should always have a value that matches the name of a
+   parameter](#pr7-self) in the function.
+8. <p id="rule-8"/>
+   When `self` is specified, then the parameter name it specifies
+   should [have the same type as the `class` specified](#pr8-self).
+9. <p id="rule-9"/>
+   [A `getter` should always return something](#pr9-getter), and must not return
+   `void` unless it is `void*`.
+10. <p id="rule-10"/>
+    [When `class` is specified with a `getter`, there should
+    always be one parameter](#pr10-getter) (the parameter for `self`).
+11. <p id="rule-11"/>
+    [When `class` is specified with a `setter`, there should
+    always be two parameters](#pr11-setter):
+
+    (i) the parameter for `self`, and
+
+    (ii) the value to set.
+
+12. <p id="rule-12"/>
+    [When `static` is specified with a `getter`, there should always be no
+    parameters](#pr12-getter).
+13. <p id="rule-13"/>
+    [When `static` is specified with a `setter`, there should always be one
+    parameter](#pr13-setter). That is, the value to set.
+14. <p id="rule-14"/>
+    [When `suffix` is used, the name must be unique to the global
+    namespace](#pr14-suffix).
+15. <p id="rule-15"/>
+    [When `suffix` is used with a `class` and `method`, the name must be unique
+    to the class namespace](#pr15-suffix).
+16. <p id="rule-16"/>
+    [When a `class` is used on a type alias, then the type alias must be an
+    alias to a pointer](#pr16-class).

--- a/src/main.rb
+++ b/src/main.rb
@@ -101,7 +101,7 @@ end
 
 #=== Translate or validate ===
 if options[:validate_only]
-  puts 'Parser succeeded with no errors 🎉'
+  puts 'SplashKit API documentation valid!'
 else
   options[:translators].each do |translator_class|
     translator = translator_class.new(parsed, options[:src])

--- a/src/parser.rb
+++ b/src/parser.rb
@@ -179,17 +179,24 @@ class Parser::HeaderFileParser
             .join('\', `')}' violate `#{getter_setter_keys_found.map(&:to_s)
             .join('\', `')}'. Choose one or the other."
     end
-    # Can't have (`destructor` | `constructor`) & `method`
-    if !destructor_constructor_keys_found.empty? && !attrs[:method].nil?
+    # Can't have (`destructor` | `constructor`) & `method` if no `static`
+    marked_with_static = !attrs[:static].nil?
+    if !destructor_constructor_keys_found.empty? &&
+       !attrs[:method].nil? &&
+       !marked_with_static
       raise Parser::Error,
             "Attribute(s) `#{destructor_constructor_keys_found.map(&:to_s)
-            .join('\', `')}' violate `method`. Choose one or the other."
+            .join('\', `')}' violate `method`. Choose one or the other " \
+            'or mark with `static` to indicate that this is a static method.'
     end
-    # Can't have (`setter` | `getter`) & `method`
-    if !getter_setter_keys_found.empty? && attrs[:method]
+    # Can't have (`setter` | `getter`) & `method` if no `static`
+    if !getter_setter_keys_found.empty? &&
+       attrs[:method] &&
+       !marked_with_static
       raise Parser::Error,
             "Attribute(s) `#{getter_setter_keys_found.map(&:to_s)
-            .join('\', `')}' violate `method`. Choose one or the other."
+            .join('\', `')}' violate `method`. Choose one or the other " \
+            'or mark with `static` to indicate that this is a static method.'
     end
     # Ensure `self` matches a parameter
     self_value = attrs[:self]

--- a/src/parser.rb
+++ b/src/parser.rb
@@ -205,7 +205,7 @@ class Parser::HeaderFileParser
       unless class_type == self_type
         raise Parser::Error,
               'Attribute `self` must list a parameter whose type matches ' \
-              'the `class` value (`class` is `#{class_type}` but `self` ' \
+              "the `class` value (`class` is `#{class_type}` but `self` " \
               "is set to parameter (`#{self_value}`) with type `#{self_type}`)"
       end
     end

--- a/src/parser.rb
+++ b/src/parser.rb
@@ -335,7 +335,7 @@ class Parser::HeaderFileParser
     is_reference = !ref.nil?
     desc = xml.xpath('result').text
     if raw_return_type.nil? && type == 'void' && desc && (is_pointer || is_reference)
-      throw Parser::Error,
+      raise Parser::Error,
             'Pure procedures should not have an `@returns` labelled.'
     end
     {

--- a/src/parser.rb
+++ b/src/parser.rb
@@ -52,9 +52,29 @@ end
 #
 class Parser::Error < StandardError
   def initialize(message, signature = nil)
+    @message = message =~ /(?:\?|\.)$/ ? message : message << '.'
     return super(message) unless signature
     @signature = signature
-    super("HeaderDoc parser error on `#{signature}`: #{message}")
+  end
+
+  def to_s
+    if @signature
+      "HeaderDoc parser error on `#{@signature}`: #{@message}"
+    else
+      @message
+    end
+  end
+end
+
+#
+# Class for raising parsing rule errors
+#
+class Parser::RuleViolationError < Parser::Error
+  attr_accessor :signature
+  def initialize(message, rule_no)
+    super message << ' See '\
+          "https://github.com/splashkit/splashkit-translator\#rule-#{rule_no} "\
+          'for more information.'
   end
 end
 
@@ -140,69 +160,71 @@ class Parser::HeaderFileParser
                .map { |a| parse_attribute(a) }
                .to_h
                .merge @header_attrs
-    # Method, self, suffix, destructor, constructor, getter, setter
-    # must have a class attribute also
+    # Method, self, destructor, constructor must have a class attribute also
     enforce_class_keys = [
       :self,
-      :suffix,
       :destructor,
       :constructor
     ]
     enforced_class_keys_found = attrs.keys & enforce_class_keys
     has_enforced_class_keys = !enforced_class_keys_found.empty?
     if has_enforced_class_keys && attrs[:class].nil?
-      raise Parser::Error,
+      raise Parser::RuleViolationError.new(
             "Attribute(s) `#{enforced_class_keys_found.map(&:to_s)
-            .join('\', `')}' found, but `class' attribute is missing?"
+            .join('\', `')}' found, but `class' attribute is missing?", 1)
     end
-    # `Method`, `getter` or `setter` must have `class` or `static`
+    # `method`, `getter` or `setter` must have `class` or `static`
     method_getter_static_keys_found = attrs.keys & [:method, :getter, :setter]
     class_static_keys_found = attrs.keys & [:class, :static]
     if !method_getter_static_keys_found.empty? &&
        class_static_keys_found.empty?
-      raise Parser::Error,
+      raise Parser::RuleViolationError.new(
             'Attributes `getter` and `setter` must also specify either ' \
-            '`class` or `static` attributes (or both).'
+            '`class` or `static` attributes (or both).', 2)
     end
     # Can't have `destructor` & `constructor`
     if attrs[:destructor] && attrs[:constructor]
-      raise Parser::Error,
-            'Attributes `destructor` and `constructor` conflict.'
+      raise Parser::RuleViolationError.new(
+            'Attributes `destructor` and `constructor` conflict.', 3)
     end
-    # Can't have (`destructor` | `constructor`) & (`setter` | `getter`)
+    # Can't have (`destructor` | `constructor`) & (`setter` | `getter`) if
+    # not marked with `static`
+    marked_with_static = !attrs[:static].nil?
     destructor_constructor_keys_found = attrs.keys & [:constructor, :destructor]
     getter_setter_keys_found = attrs.keys & [:getter, :setter]
     if !destructor_constructor_keys_found.empty? &&
-       !getter_setter_keys_found.empty?
-      raise Parser::Error,
+       !getter_setter_keys_found.empty? &&
+       !marked_with_static
+      raise Parser::RuleViolationError.new(
             "Attribute(s) `#{destructor_constructor_keys_found.map(&:to_s)
             .join('\', `')}' violate `#{getter_setter_keys_found.map(&:to_s)
-            .join('\', `')}'. Choose one or the other."
+            .join('\', `')}'. Choose one or the other.", 4)
     end
     # Can't have (`destructor` | `constructor`) & `method` if no `static`
-    marked_with_static = !attrs[:static].nil?
     if !destructor_constructor_keys_found.empty? &&
        !attrs[:method].nil? &&
        !marked_with_static
-      raise Parser::Error,
+      raise Parser::RuleViolationError.new(
             "Attribute(s) `#{destructor_constructor_keys_found.map(&:to_s)
             .join('\', `')}' violate `method`. Choose one or the other " \
-            'or mark with `static` to indicate that this is a static method.'
+            'or mark with `static` to indicate that this is a static ' \
+            'method.', 5)
     end
     # Can't have (`setter` | `getter`) & `method` if no `static`
     if !getter_setter_keys_found.empty? &&
        attrs[:method] &&
        !marked_with_static
-      raise Parser::Error,
+      raise Parser::RuleViolationError.new(
             "Attribute(s) `#{getter_setter_keys_found.map(&:to_s)
             .join('\', `')}' violate `method`. Choose one or the other " \
-            'or mark with `static` to indicate that this is a static method.'
+            'or mark with `static` to indicate that this is a static ' \
+            'method.', 6)
     end
     # Ensure `self` matches a parameter
     self_value = attrs[:self]
     if self_value && ppl && ppl[self_value.to_sym].nil?
-      raise Parser::Error,
-            'Attribute `self` must be set to the name of a parameter.'
+      raise Parser::RuleViolationError.new(
+            'Attribute `self` must be set to the name of a parameter.', 7)
     end
     # Ensure the parameter set by `self` attribute has the same type indicated
     # by the `class`
@@ -210,47 +232,50 @@ class Parser::HeaderFileParser
       class_type = attrs[:class]
       self_type  = ppl[self_value.to_sym]
       unless class_type == self_type
-        raise Parser::Error,
+        raise Parser::RuleViolationError.new(
               'Attribute `self` must list a parameter whose type matches ' \
               "the `class` value (`class` is `#{class_type}` but `self` " \
-              "is set to parameter (`#{self_value}`) with type `#{self_type}`)"
+              "is set to parameter (`#{self_value}`) with type " \
+              "`#{self_type}`).", 8)
       end
     end
     # `getter` must be non-void
     ret_type = parse_function_return_type(xml)
     is_void = ret_type && ret_type[:type] == 'void' && !ret_type[:is_pointer]
     if attrs[:getter] && is_void
-      raise Parser::Error,
-            'Function marked with `getter` must return something (returns void)'
+      raise Parser::RuleViolationError.new(
+            'Function marked with `getter` must return something (i.e., '\
+            'it should not return `void`).', 9)
     end
     # `class` rules applicable to `getter`s and `setter`s
     if attrs[:class]
       # Getters must have 1 parameter which is self
       if attrs[:getters] && ppl && ppl.length != 1 && attrs[:self]
-        raise Parser::Error,
+        raise Parser::RuleViolationError.new(
               'A `getter` specified with `class` must have exactly one '\
               'parameter that is the parameter specified by the '\
-              'attribute `self`'
+              'attribute `self`.', 10)
       end
       # Setters must have 2 parameters
       if attrs[:setters] && ppl && ppl.length != 2 && attrs[:self] == ppl.keys.first
-        raise Parser::Error,
+        raise Parser::RuleViolationError.new(
               'A `setter` specified with `class` must have exactly two '\
               'parameters of which the first parameter is the parameter '\
-              'specified by the attribute `self`'
+              'specified by the attribute `self`.', 11)
       end
     end
     # `static` rules applicable to `getter`s and `setter`s
     if attrs[:class]
       # Getters must have 0 parameters
       if attrs[:getters] && ppl && ppl.empty?
-        raise Parser::Error,
-              'A `getter` specified with `static` must have no parameters'
+        raise Parser::RuleViolationError.new(
+              'A `getter` specified with `static` must have no parameters',
+              12)
       end
       # Setters must have 2 parameters
       if attrs[:setters] && ppl && ppl.length != 2
-        raise Parser::Error,
-              'A `setter` specified with `static` must have one parameter'
+        raise Parser::RuleViolationError.new(
+              'A `setter` specified with `static` must have one parameter', 13)
       end
     end
     attrs
@@ -368,9 +393,9 @@ class Parser::HeaderFileParser
     unless unique_global_name.nil?
       # Check if unique name is actually unique
       if @unique_names[:unique_global].include? unique_global_name
-        raise Parser::Error,
+        raise Parser::RuleViolationError.new(
               'Generated unique name (function name + suffix) is not unique: ' \
-              "`#{sanitized_name}` + `#{suffix}` = `#{unique_global_name}`"
+              "`#{sanitized_name}` + `#{suffix}` = `#{unique_global_name}`", 14)
       else
         @unique_names[:unique_global] << unique_global_name
       end
@@ -379,9 +404,9 @@ class Parser::HeaderFileParser
     unless unique_method_name.nil?
       # Check if unique method name is actually unique
       if @unique_names[:unique_method].include? unique_method_name
-        raise Parser::Error,
+        raise Parser::RuleViolationError.new(
               'Generated unique method name (method + suffix) is not unique: ' \
-              "`#{method}` + `#{suffix}` = `#{unique_method_name}`"
+              "`#{method}` + `#{suffix}` = `#{unique_method_name}`", 15)
       # Else register the unique name
       else
         @unique_names[:unique_method] << unique_method_name
@@ -420,7 +445,8 @@ class Parser::HeaderFileParser
       attributes:         attributes
     }
   rescue Parser::Error => e
-    raise Parser::Error.new e.message, signature
+    e.signature = signature
+    raise e
   end
 
   #
@@ -486,12 +512,13 @@ class Parser::HeaderFileParser
       is_function_pointer: is_fn_ptr
     }.merge merge_data
     if attributes && attributes[:class].nil? && data[:is_pointer]
-      raise Parser::Error,
-            'Typealiases to pointers must have a class attribute set'
+      raise Parser::RuleViolationError.new(
+            'Typealiases to pointers must have a class attribute set', 16)
     end
     data
   rescue Parser::Error => e
-    raise Parser::Error.new e.message, signature
+    e.signature = signature
+    raise e
   end
 
   #
@@ -527,7 +554,8 @@ class Parser::HeaderFileParser
       attributes:  parse_attributes(xml)
     }
   rescue Parser::Error => e
-    raise Parser::Error.new e.message, signature
+    e.signature = signature
+    raise e
   end
 
   #
@@ -571,7 +599,8 @@ class Parser::HeaderFileParser
       attributes:  parse_attributes(xml)
     }
   rescue Parser::Error => e
-    raise Parser::Error.new e.message, signature
+    e.signature = signature
+    raise e
   end
 
   #

--- a/src/parser.rb
+++ b/src/parser.rb
@@ -19,6 +19,9 @@ module Parser
   # Parses HeaderDoc for the provided src directory into a hash
   #
   def parse(src)
+    unless Parser.headerdoc_installed?
+      raise Parser::Error 'headerdoc2html is not installed!'
+    end
     hcfg_file = File.expand_path('../../res/headerdoc.config', __FILE__)
     # If only parsing one file then don't amend /*.h
     headers_src = "#{src}/#{SK_SRC_CORESDK}/*.h" unless src.end_with? '.h'

--- a/src/translators/cpp.rb
+++ b/src/translators/cpp.rb
@@ -1,0 +1,41 @@
+require_relative 'abstract_translator'
+
+module Translators
+  #
+  # C++ Front-End Translator
+  #
+  class CPP < AbstractTranslator
+    def render_templates
+      {
+        'sklib.h' => read_template('cpp.cpp'),
+        'sklib.cpp' => read_template('cpp.h'),
+        'CMakeLists.txt' => read_template('CMakeLists.txt')
+      }
+    end
+
+    #
+    # Generate a C++ type signature from a SK function
+    #
+    def cpp_signature_for(function)
+      name            = function[:name]
+      return_type     = function[:return]
+      parameter_list  = cpp_parameter_list_for function
+      "#{return_type} #{name}(#{parameter_list})"
+    end
+
+    #
+    # Convert a list of parameters to a C++ parameter list
+    #
+    def cpp_parameter_list_for(function)
+      function[:parameters].reduce('') do |memo, param|
+        param_name = param.first
+        param_data = param.last
+        type = param_data[:type]
+        ptr = param_data[:is_pointer]   ? '*' : ''
+        ref = param_data[:is_reference] ? '&' : ''
+        const = param_data[:is_const] ? 'const ' : ''
+        "#{memo}, #{const}#{type} #{ptr}#{ref}#{param_name}"
+      end[2..-1]
+    end
+  end
+end


### PR DESCRIPTION
When parser violation rule is thrown, a link is generated directly to that rule. The rule summary describes the violation in a sentence or two and has links to the documentation that describes it in more detail.
