### PR TITLE
New/add vector support

### DIFF
--- a/res/translators/clib/functions/implementations.cpp.erb
+++ b/res/translators/clib/functions/implementations.cpp.erb
@@ -18,12 +18,12 @@
         if param_data[:is_pointer]
           param_name
         else
-          deref = param_data[:is_reference] ? '*' : ''
+          deref = (param_data[:is_reference] && ! param_data[:is_const]) ? '*' : ''
           adapter_fn = sk_adapter_fn_for param_data
           "#{adapter_fn}(#{deref}#{param_name})"
         end
       ptr = param_data[:is_pointer] ? '*' : ''
-      const = param_data[:is_const] ? 'const ' : ''
+      const = (param_data[:is_const] && !param_data[:is_reference]) ? 'const ' : ''
       type = param_data[:type]
       type_p = param_data[:type_p] ? "<#{param_data[:type_p]}>" : ''
       lib_param_decl = "#{const}#{type}#{type_p} #{ptr}__skparam__#{param_name}"

--- a/res/translators/clib/functions/implementations.cpp.erb
+++ b/res/translators/clib/functions/implementations.cpp.erb
@@ -25,7 +25,8 @@
       ptr = param_data[:is_pointer] ? '*' : ''
       const = param_data[:is_const] ? 'const ' : ''
       type = param_data[:type]
-      lib_param_decl = "#{const}#{type} #{ptr}__skparam__#{param_name}"
+      type_p = param_data[:type_p] ? "<#{param_data[:type_p]}>" : ''
+      lib_param_decl = "#{const}#{type}#{type_p} #{ptr}__skparam__#{param_name}"
 %>
     <%= lib_param_decl %> = <%= param_adapted %>;
 <%
@@ -36,7 +37,8 @@
 %>
 <%
     return_val = unless is_void?(function) then
-      "#{function[:return][:type]} __skreturn = "
+      type_p = function[:return][:type_p] ? "<#{function[:return][:type_p]}>" : ''
+      "#{function[:return][:type]}#{type_p} __skreturn = "
     end
     param_list = function[:parameters].map do |param_name, _|
       "__skparam__#{param_name}"

--- a/res/translators/clib/sk_clib.h.erb
+++ b/res/translators/clib/sk_clib.h.erb
@@ -31,6 +31,7 @@ using namespace splashkit_lib;
 namespace __sklib_ns {
     <%= read_template('types/types').indent %>
 
+    <%= read_template('vectors/vectors').indent %>
 }
 
 using namespace __sklib_ns;

--- a/res/translators/clib/types/string.cpp.erb
+++ b/res/translators/clib/types/string.cpp.erb
@@ -10,23 +10,28 @@
     6. Free the returned `__sklib_string' from the heap
     7. Return the wrapped `Bar::String'
 %>
-typedef struct {
+typedef struct
+{
   char *string;
   int size;
 } __sklib_string;
-__sklib_string __skadapter__to_sklib_string(std::string s) {
+__sklib_string __skadapter__to_sklib_string(const std::string &s)
+{
     __sklib_string __skreturn;
     __skreturn.size = (int)s.length();
     __skreturn.string = (char *)malloc(__skreturn.size + 1);
     strcpy(__skreturn.string, s.c_str());
     return __skreturn;
 }
-void __skadapter__free_sklib_string_internal_pointer(char *s, int size) {
-    free(s);
-}
-void __skadapter__free_sklib_string(__sklib_string s) {
+void __skadapter__free__sklib_string(__sklib_string s) //TODO: Needs to be callable from adapter (in lib)
+{
     free(s.string);
 }
-std::string __skadapter__to_string(__sklib_string s) {
-    return std::string(s.string);
+std::string __skadapter__to_string(const __sklib_string &s)
+{
+    std:string result = std::string(s.string);
+#ifdef BUILDING_SK_ADAPTER
+    __skadapter__free__sklib_string(s); //TODO: Should be calling __sklib__ to free as it created this!
+#endif
+     return result;
 }

--- a/res/translators/clib/vectors/vectors.cpp.erb
+++ b/res/translators/clib/vectors/vectors.cpp.erb
@@ -1,0 +1,52 @@
+<%#
+    Dynamic arrays from a std::vector<T> in the SK code must be allocated on
+    the heap and freed after use. An example would be:
+
+    1. SK function `Foo' returns a `std::vector<T>' (eg `vector<int>`)
+    2. Convert `std::vector<T>' as `__sklib_vector_<T>'
+       (eg `__sklib_vector_int`)
+    3. Return `__sklib_vector_<T>'
+    4. Language `Bar' calls Lib function `Foo' returning the
+       `__sklib_vector_<T>`
+    5. A dynamic array is created in language `Bar`
+    6. The contents of the `__sklib_vector_<T>`
+    6. Free the returned `__sklib_string' from the heap
+    7. Return the wrapped `Bar::String'
+%>
+<%
+  @vector_types.each do |vector|
+%>
+typedef struct {
+    <%= lib_map_type_for(vector[:type_p]) %> *data;
+    unsigned int size;
+} __sklib_vector_<%= vector[:type_p] %>;
+__sklib_vector_<%= vector[:type_p] %> __skadapter__to_sklib_vector_<%= vector[:type_p] %>(std::vector<<%= vector[:type_p] %>> &input)
+{
+    __sklib_vector_<%= vector[:type_p] %> __skreturn;
+    __skreturn.size = input.size();
+    __skreturn.data = (<%= lib_map_type_for(vector[:type_p]) %> *)malloc(__skreturn.size * sizeof(<%= lib_map_type_for(vector[:type_p]) %>));
+    int i = 0;
+    for(<%= vector[:type_p] %> d : input)
+    {
+      __skreturn.data[i] = __skadapter__to_sklib_<%= vector[:type_p] %>(d);
+      i++;
+    }
+    return __skreturn;
+}
+void __skadapter__free_sklib_vector_<%= vector[:type_p] %>(__sklib_vector_<%= vector[:type_p] %> &to_free)
+{
+    free(to_free.data);
+}
+vector<<%= vector[:type_p] %>> __skadapter__to_vector_<%= vector[:type_p] %>(__sklib_vector_<%= vector[:type_p] %> &input)
+{
+    vector<<%= vector[:type_p] %>> __skreturn;
+    for(int i = 0; i < input.size; i++)
+    {
+        __skreturn.push_back(__skadapter__to_<%= vector[:type_p] %>(input.data[i]));
+    }
+    __skadapter__free_sklib_vector_<%= vector[:type_p] %>(input);
+    return __skreturn;
+}
+<%
+  end # end functions.each
+%>

--- a/res/translators/clib/vectors/vectors.cpp.erb
+++ b/res/translators/clib/vectors/vectors.cpp.erb
@@ -20,7 +20,7 @@ typedef struct {
     <%= lib_map_type_for(vector[:type_p]) %> *data;
     unsigned int size;
 } __sklib_vector_<%= vector[:type_p] %>;
-__sklib_vector_<%= vector[:type_p] %> __skadapter__to_sklib_vector_<%= vector[:type_p] %>(std::vector<<%= vector[:type_p] %>> &input)
+__sklib_vector_<%= vector[:type_p] %> __skadapter__to_sklib_vector_<%= vector[:type_p] %>(const std::vector<<%= vector[:type_p] %>> &input)
 {
     __sklib_vector_<%= vector[:type_p] %> __skreturn;
     __skreturn.size = input.size();
@@ -33,18 +33,30 @@ __sklib_vector_<%= vector[:type_p] %> __skadapter__to_sklib_vector_<%= vector[:t
     }
     return __skreturn;
 }
-void __skadapter__free_sklib_vector_<%= vector[:type_p] %>(__sklib_vector_<%= vector[:type_p] %> &to_free)
+void __skadapter__free__sklib_vector_<%= vector[:type_p] %>(__sklib_vector_<%= vector[:type_p] %> to_free)
 {
+<%
+  if( vector[:type_p] == 'string' )
+%>
+    for(int i = 0; i < to_free.size; i++)
+    {
+        __skadapter__free__sklib_string(to_free.data[i]);
+    }
+<%
+  end
+%>
     free(to_free.data);
 }
-vector<<%= vector[:type_p] %>> __skadapter__to_vector_<%= vector[:type_p] %>(__sklib_vector_<%= vector[:type_p] %> &input)
+vector<<%= vector[:type_p] %>> __skadapter__to_vector_<%= vector[:type_p] %>(const __sklib_vector_<%= vector[:type_p] %> &input)
 {
     vector<<%= vector[:type_p] %>> __skreturn;
     for(int i = 0; i < input.size; i++)
     {
         __skreturn.push_back(__skadapter__to_<%= vector[:type_p] %>(input.data[i]));
     }
-    __skadapter__free_sklib_vector_<%= vector[:type_p] %>(input);
+#ifdef BUILDING_SK_ADAPTER
+    __skadapter__free__sklib_vector_<%= vector[:type_p] %>(input); //TODO: Should be calling __sklib__ to free as it created this!
+#endif
     return __skreturn;
 }
 <%

--- a/res/translators/cpp/header/module_header.h.erb
+++ b/res/translators/cpp/header/module_header.h.erb
@@ -25,6 +25,9 @@ header = "__#{@data[:name]}_h"
 #include <string>
 using std::string;
 
+#include <vector>
+using std::vector;
+
 <%#
     Define macros for the header here
 %>

--- a/res/translators/cpp/implementation/function.cpp.erb
+++ b/res/translators/cpp/implementation/function.cpp.erb
@@ -63,7 +63,21 @@
     end # end non_const_ptrs.each
 %>
 <%#
-    4. Return __skreturn variable if non-void
+    4. Free any string or vector parameters
+%>
+<%
+    params_to_free = function[:parameters].select do | _, param_data |
+      param_data[:type] == 'string' || param_data[:type] == 'vector'
+    end # end select
+    params_to_free.each do | param_name, param_data |
+      type_name = @clib.lib_type_for(param_data)
+%>
+    __skadapter__free<%=type_name%>(__skparam__<%=param_name%>);
+<%
+    end # end do
+%>
+<%#
+    5. Return __skreturn variable if non-void
 %>
 <%
     unless is_void?(function)

--- a/res/translators/cpp/implementation/function.cpp.erb
+++ b/res/translators/cpp/implementation/function.cpp.erb
@@ -42,7 +42,7 @@
     end
     lib_fn_name = @clib.lib_function_name_for(function)
     param_list = function[:parameters].map do |param_name, param_data|
-      address_of_oper = param_data[:is_reference] ? '&' : ''
+      address_of_oper = (param_data[:is_reference] && !param_data[:is_const]) ? '&' : ''
       "#{address_of_oper}__skparam__#{param_name}"
     end.join(', ')
     func_call  = "#{return_val}#{lib_fn_name}(#{param_list})"

--- a/res/translators/cpp/implementation/implementation.cpp.erb
+++ b/res/translators/cpp/implementation/implementation.cpp.erb
@@ -1,13 +1,17 @@
 #include "splashkit.h"
 #include <string>
-#include <stdlib.h>
+#include <vector>
+#include <cstdlib>
 using std::string;
+using std::vector;
+
 
 <%#
     Can re-use the templates for C library types (and adapters)
     and function prototypes seeing as they would be the same
 %>
 <%= @clib.read_template 'types/types' %>
+<%= @clib.read_template 'vectors/vectors' %>
 <%= @clib.read_template 'functions/prototypes' %>
 
 <%#

--- a/src/parser.rb
+++ b/src/parser.rb
@@ -313,7 +313,7 @@ class Parser::HeaderFileParser
     _, const, type, ref, ptr = *(ppl_type_data.match regex)
 
     #Grab template <T> value for parameter
-    regex = /<declaration_type>vector<\/declaration_type>&lt;<declaration_template>(\w+?)<\/declaration_template>&gt; <declaration_param>#{param_name}<\/declaration_param>/
+    regex = /<declaration_type>vector<\/declaration_type>&lt;<declaration_template>(\w+?)<\/declaration_template>&gt; (\s*&amp;)?<declaration_param>#{param_name}<\/declaration_param>/
     _, type_p = *(xml.to_s.match regex)
 
     array = parse_array_dimensions(xml, param_name)
@@ -322,7 +322,7 @@ class Parser::HeaderFileParser
       description: xml.xpath('desc').text,
       is_pointer: !ptr.nil?,
       is_const: !const.nil?,
-      is_reference: !ref.nil?,
+      is_reference: (!ref.nil?) && (const.nil?), # copy const refs
       is_array: !array.empty?,
       array_dimension_sizes: array,
       type_p: type_p

--- a/src/parser.rb
+++ b/src/parser.rb
@@ -322,7 +322,7 @@ class Parser::HeaderFileParser
       description: xml.xpath('desc').text,
       is_pointer: !ptr.nil?,
       is_const: !const.nil?,
-      is_reference: (!ref.nil?) && (const.nil?), # copy const refs
+      is_reference: (!ref.nil?),
       is_array: !array.empty?,
       array_dimension_sizes: array,
       type_p: type_p

--- a/src/parser.rb
+++ b/src/parser.rb
@@ -311,6 +311,11 @@ class Parser::HeaderFileParser
   def parse_parameter_info(xml, param_name, ppl_type_data)
     regex = /(?:(const)\s+)?((?:unsigned\s)?\w+)\s*(?:(&amp;)|(\*)|(\[\d+\])*)?/
     _, const, type, ref, ptr = *(ppl_type_data.match regex)
+
+    #Grab template <T> value for parameter
+    regex = /<declaration_type>vector<\/declaration_type>&lt;<declaration_template>(\w+?)<\/declaration_template>&gt; <declaration_param>#{param_name}<\/declaration_param>/
+    _, type_p = *(xml.to_s.match regex)
+
     array = parse_array_dimensions(xml, param_name)
     {
       type: type,
@@ -319,7 +324,8 @@ class Parser::HeaderFileParser
       is_const: !const.nil?,
       is_reference: !ref.nil?,
       is_array: !array.empty?,
-      array_dimension_sizes: array
+      array_dimension_sizes: array,
+      type_p: type_p
     }
   end
 
@@ -364,16 +370,23 @@ class Parser::HeaderFileParser
     _, type, ref, ptr = *(raw_return_type.match ret_type_regex)
     is_pointer = !ptr.nil?
     is_reference = !ref.nil?
+
+    # Extract <T> from generic returns
+    regex = /<declaration_type>vector<\/declaration_type>&lt;<declaration_template>(\w+?)<\/declaration_template>&gt; <declaration_function>/
+    _, type_p = *(xml.to_s.match regex)
+
     desc = xml.xpath('result').text
     if raw_return_type.nil? && type == 'void' && desc && (is_pointer || is_reference)
       raise Parser::Error,
             'Pure procedures should not have an `@returns` labelled.'
     end
+
     {
       type: type,
       is_pointer: is_pointer,
       is_reference: is_reference,
-      description: desc
+      description: desc,
+      type_p: type_p
     }
   end
 

--- a/src/translators/abstract_translator.rb
+++ b/src/translators/abstract_translator.rb
@@ -41,7 +41,6 @@ module Translators
           result << fn[:parameters].values.select { |param| param[:type] == "vector" }.map { |param| { type_p: param[:type_p] } }
           result
         end.flatten.uniq
-      puts "vector types: #{@vector_types}"
     end
 
     #

--- a/src/translators/abstract_translator.rb
+++ b/src/translators/abstract_translator.rb
@@ -31,6 +31,17 @@ module Translators
       @structs = @data[:structs] || @data.values.pluck(:structs).flatten
       @functions = @data[:functions] || @data.values.pluck(:functions).flatten
       @defines = @data[:defines] || @data.values.pluck(:defines).flatten
+
+      @vector_types =
+        @functions.map do |fn|
+          result = []
+          if fn[:return][:type] == "vector"
+            result << { type_p: fn[:return][:type_p] }
+          end
+          result << fn[:parameters].values.select { |param| param[:type] == "vector" }.map { |param| { type_p: param[:type_p] } }
+          result
+        end.flatten.uniq
+      puts "vector types: #{@vector_types}"
     end
 
     #

--- a/src/translators/clib.rb
+++ b/src/translators/clib.rb
@@ -99,7 +99,8 @@ module Translators
           'enum'      => 'int',
           'struct'    => "__sklib_#{type}",
           'string'    => '__sklib_string',
-          'typealias' => '__sklib_ptr'
+          'typealias' => '__sklib_ptr',
+          'vector'    => "__sklib_vector_#{type_data[:type_p]}"
         }
       result = direct_map[raw_type_for(type)]
       raise "The type `#{type}` cannot yet be translated into a compatible "\

--- a/src/translators/clib.rb
+++ b/src/translators/clib.rb
@@ -71,7 +71,7 @@ module Translators
         param_data = param.last
         type = lib_type_for param_data
         # If a C++ reference, we must convert to a C pointer
-        ptr = param_data[:is_pointer] || param_data[:is_reference] ? '*' : ''
+        ptr = param_data[:is_pointer] || (param_data[:is_reference] && ! param_data[:is_const]) ? '*' : ''
         const = param_data[:is_const] ? 'const ' : ''
         "#{memo}, #{const}#{type} #{ptr}#{param_name}"
       end[2..-1]

--- a/src/translators/cpp.rb
+++ b/src/translators/cpp.rb
@@ -127,7 +127,8 @@ module Translators
     def cpp_type_for(type_data)
       # Only hardcode mapping we need
       return 'unsigned char' if type_data[:type] == 'byte'
-      type_data[:type]
+      type_p = type_data[:type_p] ? "<#{type_data[:type_p]}>" : ''
+      "#{type_data[:type]}#{type_p}"
     end
 
     #

--- a/src/translators/cpp.rb
+++ b/src/translators/cpp.rb
@@ -96,8 +96,8 @@ module Translators
         param_data = param.last
         type = cpp_type_for param_data
         ptr = param_data[:is_pointer]   ? '*' : ''
-        ref = param_data[:is_reference] ? '&' : ''
-        const = param_data[:is_const] ? 'const ' : ''
+        ref = (param_data[:is_reference]) ? '&' : ''
+        const = (param_data[:is_const]) ? 'const ' : ''
         "#{memo}, #{const}#{type} #{ptr}#{ref}#{param_name}"
       end[2..-1]
     end

--- a/test/vectors/with_vector.cpp
+++ b/test/vectors/with_vector.cpp
@@ -3,7 +3,7 @@
 // ./translate --generate clib,cpp -i test/vectors/with_vector.h --output test/out
 //
 // Make static library:
-// clang++ clang++ -DBUILDING_SK_LIB -std=c++14 -c with_vector.cpp ../out/clib/sk_clib.cpp -I../clib -I../..
+// clang++ -DBUILDING_SK_LIB -std=c++14 -c with_vector.cpp ../out/clib/sk_clib.cpp -I../clib -I../..
 // libtool -static -o libSplashKitBackend.a with_vector.o sk_clib.o
 //
 // Make dynamic library

--- a/test/vectors/with_vector.cpp
+++ b/test/vectors/with_vector.cpp
@@ -1,3 +1,20 @@
+//
+// Generate adapter
+// ./translate --generate clib,cpp -i test/vectors/with_vector.h --output test/out
+//
+// Make static library:
+// clang++ clang++ -DBUILDING_SK_LIB -std=c++14 -c with_vector.cpp ../out/clib/sk_clib.cpp -I../clib -I../..
+// libtool -static -o libSplashKitBackend.a with_vector.o sk_clib.o
+//
+// Make dynamic library
+// clang++ -DBUILDING_SK_ADAPTER -std=c++14 -shared -g splashkit.cpp -I../clib -I../../.. -L../../vectors -lSplashKitBackend -o libSplashKit.dylib -Wl,-install_name,'@rpath/libSplashKit.dylib'
+// mv libSplashKit.dylib ../../vectors/
+//
+// Compile program
+// mv with_vector.h with_vector.h.old
+// clang++ -g -std=c++14 with_vector_test.cpp -L. -lSplashKit -I../out/cpp -Wl,-rpath,@loader_path
+// mv with_vector.h.old with_vector.h
+//
 #include "with_vector.h"
 
 #include <iostream>
@@ -5,7 +22,13 @@ using namespace std;
 
 namespace splashkit_lib
 {
-  void print_string_list(vector<string> j, int x)
+  string print_string(const string &message)
+  {
+    cout << message << endl;
+    return message;
+  }
+
+  void print_string_list(const vector<string> &j, int x)
   {
     for(string s : j)
     {
@@ -19,11 +42,11 @@ namespace splashkit_lib
    *
    * @param j The list
    */
-  void print_float_list(vector<float> j)
+  void print_float_list(const vector<float> &j)
   {
     for(float s : j)
     {
-      cout << s << endl;
+      // cout << s << endl;
     }
     cout << "end" << endl << endl;
   }

--- a/test/vectors/with_vector.cpp
+++ b/test/vectors/with_vector.cpp
@@ -1,0 +1,49 @@
+#include "with_vector.h"
+
+#include <iostream>
+using namespace std;
+
+namespace splashkit_lib
+{
+  void print_string_list(vector<string> j, int x)
+  {
+    for(string s : j)
+    {
+      cout << s << " " << x << endl;
+    }
+    cout << "end" << endl << endl;
+  }
+
+  /**
+   * Prints values from the list.
+   *
+   * @param j The list
+   */
+  void print_float_list(vector<float> j)
+  {
+    for(float s : j)
+    {
+      cout << s << endl;
+    }
+    cout << "end" << endl << endl;
+  }
+
+
+  /**
+   * Adds an array of `json` object values to the `json` object for
+   * the given `string` key.
+   *
+   * @param count The number of values
+   * @returns Values 1 to count in a vector
+   */
+  vector<float> get_number_list(int count)
+  {
+    std::vector<float> v;
+    for (size_t i = 0; i < count; i++)
+    {
+      v.push_back(i * 1.0f + i * 0.1f);
+    }
+
+    return v;
+  }
+}

--- a/test/vectors/with_vector.h
+++ b/test/vectors/with_vector.h
@@ -5,20 +5,28 @@ using namespace std;
 namespace splashkit_lib
 {
   /**
+   * description.
+   *
+   * @param message message
+   * @returns message
+   */
+  string print_string(const string &message);
+
+  /**
    * Adds an array of `json` object values to the `json` object for
    * the given `string` key.
    *
    * @param j List to print
    * @param x An int
    */
-  void print_string_list(vector<string> j, int x);
+  void print_string_list(const vector<string> &j, int x);
 
   /**
    * Prints values from the list.
    *
    * @param j The list
    */
-  void print_float_list(vector<float> j);
+  void print_float_list(const vector<float> &j);
 
 
   /**

--- a/test/vectors/with_vector.h
+++ b/test/vectors/with_vector.h
@@ -1,0 +1,32 @@
+#include <vector>
+#include <string>
+using namespace std;
+
+namespace splashkit_lib
+{
+  /**
+   * Adds an array of `json` object values to the `json` object for
+   * the given `string` key.
+   *
+   * @param j List to print
+   * @param x An int
+   */
+  void print_string_list(vector<string> j, int x);
+
+  /**
+   * Prints values from the list.
+   *
+   * @param j The list
+   */
+  void print_float_list(vector<float> j);
+
+
+  /**
+   * Adds an array of `json` object values to the `json` object for
+   * the given `string` key.
+   *
+   * @param count The number of values
+   * @returns Values 1 to count in a vector
+   */
+  vector<float> get_number_list(int count);
+}

--- a/test/vectors/with_vector_test.cpp
+++ b/test/vectors/with_vector_test.cpp
@@ -1,0 +1,22 @@
+#include "with_vector.h"
+
+// using namespace splashkit;
+
+int main()
+{
+  std::vector<string> v;
+  v.push_back("-----");
+  v.push_back("Hello");
+  v.push_back("World");
+  v.push_back("-----");
+
+  print_string_list(v, 10);
+
+  std::vector<float> nums;
+
+  nums = get_number_list(100);
+
+  print_float_list(nums);
+
+  return 0;
+}

--- a/test/vectors/with_vector_test.cpp
+++ b/test/vectors/with_vector_test.cpp
@@ -4,7 +4,12 @@
 
 int main()
 {
+  for (size_t i = 0; i < 100000; i++) {
+    std::string str = print_string("Hello World");
+  }
+
   std::vector<string> v;
+  // v.push_back(str);
   v.push_back("-----");
   v.push_back("Hello");
   v.push_back("World");
@@ -16,7 +21,9 @@ int main()
 
   nums = get_number_list(100);
 
-  print_float_list(nums);
+  for (size_t i = 0; i < 100000; i++) {
+    print_float_list(nums);
+  }
 
   return 0;
 }


### PR DESCRIPTION
Adds the ability to parse and transfer vectors between splashkit and adapter languages.
- Turns vectors into heap allocated array in struct with size
- Copies data into array on pass
- Frees parameters after call
- Frees result in adapter on return
- Fixes memory leaks issues for string parameters and results

Have tested in Instruments for leaks... and all good!
