### PR TITLE
Add improved support for suppressing HeaderDoc warnings and errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,5 @@ source 'https://rubygems.org'
 
 gem 'nokogiri'
 gem 'hashie', '3.4.4'
+
+gem 'colorize', '0.8.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    colorize (0.8.1)
     hashie (3.4.4)
     mini_portile2 (2.1.0)
     nokogiri (1.6.8)
@@ -12,6 +13,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  colorize (= 0.8.1)
   hashie (= 3.4.4)
   nokogiri
 

--- a/src/logger.rb
+++ b/src/logger.rb
@@ -1,0 +1,34 @@
+#
+# Logging module
+#
+module Logger
+  #
+  # Defines variables
+  #
+  def warnings
+    @@warnings ||= []
+  end
+
+  #
+  # Defines errors
+  #
+  def errors
+    @@errors ||= []
+  end
+
+  private
+
+  #
+  # Warning in parser
+  #
+  def warn(msg)
+    warnings << msg
+  end
+
+  #
+  # Error in parser
+  #
+  def error(msg)
+    errors << msg.to_s
+  end
+end

--- a/src/main.rb
+++ b/src/main.rb
@@ -45,7 +45,7 @@ EOS
 Source header file or SplashKit CoreSDK directory
 EOS
   opts.on('-i', '--input SOURCE', help) do |input|
-    options[:src] = input
+    options[:src] = File.expand_path input
     options[:out] = "#{input}/#{SK_TRANSLATED_OUTPUT}"
   end
   # Generate using translator
@@ -67,7 +67,7 @@ EOS
 Directory to write output to (defaults to /path/to/splashkit/out/translated)
 EOS
   opts.on('-o', '--output OUTPUT', help) do |out|
-    options[:out] = out
+    options[:out] = File.expand_path out
   end
   # Validate only (don't generate)
   help = <<-EOS


### PR DESCRIPTION
- Adding `-b` for verbose will display all HeaderDoc warnings.
- All fatal errors (such as violating `attribute`s) will display as errors after parsing
