### PR TITLE
Fix/vectors

### DIFF
--- a/res/translators/clib/functions/implementations.cpp.erb
+++ b/res/translators/clib/functions/implementations.cpp.erb
@@ -48,6 +48,8 @@
     <%= func_call %>;
 <%#
     3. Update all non-const references.
+        -- if it can be directly copied... do that.
+        -- otherwise use the types update function
 %>
 <%
     non_const_refs = function[:parameters].select do | _, param_data |

--- a/res/translators/clib/functions/implementations.cpp.erb
+++ b/res/translators/clib/functions/implementations.cpp.erb
@@ -54,9 +54,19 @@
       param_data[:is_reference] && !param_data[:is_const]
     end # end select
     non_const_refs.each do | param_name, param_data |
-      adapter_fn = lib_adapter_fn_for param_data
+      if type_can_be_directly_copies? param_data
+        adapter_fn = lib_adapter_fn_for param_data
 %>
     *<%= param_name %> = <%= adapter_fn %>(__skparam__<%= param_name %>);
+<%
+      else # cannot be directly copied...
+%>
+
+<%
+    end # end if can be directly copied
+%>
+
+
 <%
     end # end non_const_ptrs.each
 %>

--- a/res/translators/clib/functions/implementations.cpp.erb
+++ b/res/translators/clib/functions/implementations.cpp.erb
@@ -54,20 +54,17 @@
       param_data[:is_reference] && !param_data[:is_const]
     end # end select
     non_const_refs.each do | param_name, param_data |
-      if type_can_be_directly_copies? param_data
+      if type_can_be_directly_copied? param_data
         adapter_fn = lib_adapter_fn_for param_data
 %>
     *<%= param_name %> = <%= adapter_fn %>(__skparam__<%= param_name %>);
 <%
       else # cannot be directly copied...
+        update_fn = sk_update_fn_for param_data
 %>
-
+    <%= update_fn %>(__skparam__<%= param_name %>, <%= param_name %>);
 <%
-    end # end if can be directly copied
-%>
-
-
-<%
+      end # end if can be directly copied
     end # end non_const_ptrs.each
 %>
 <%#

--- a/res/translators/clib/types/vectors.cpp.erb
+++ b/res/translators/clib/types/vectors.cpp.erb
@@ -22,9 +22,24 @@
 //-----------------------------------------------------------------------------
 
 typedef struct {
-    <%= lib_map_type_for(type) %> *data;
-    unsigned int size;
+    // Values passed to SplashKit will come in here...
+    <%= lib_map_type_for(type) %> *data_from_app;
+    unsigned int size_from_app;
+
+    // Values returns will come through here...
+    <%= lib_map_type_for(type) %> *data_from_lib;
+    unsigned int size_from_lib;
 } __sklib_vector_<%= type %>;
+
+<%
+    if is_splashkit_library?
+      update_field_suffix = "_from_lib"
+      read_field_suffix = "_from_app"
+    else
+      update_field_suffix = "_from_app"
+      read_field_suffix = "_from_lib"
+    end
+%>
 
 <%
     # Must forward declare C Library free function if not yet declared
@@ -42,25 +57,28 @@ extern "C" void <%= CLib::FUNC_PREFIX %>__free__sklib_vector_<%= type %>(__sklib
     if type == 'string'
 %>
     // Freeing vector<string> requires us to free the strings within the vector
-    for (unsigned int i = 0; i < v.size; i++)
+    for (unsigned int i = 0; i < v.size<%= update_field_suffix %>; i++)
     {
-        <%= func_prefix %>__free__sklib_string(v.data[i]);
+        <%= func_prefix %>__free__sklib_string(v.data<%= update_field_suffix %>[i]);
     }
 <%
     end # end if type is string
 %>
-    free(v.data);
+    free(v.data<%= update_field_suffix %>);
 }
 
 __sklib_vector_<%= type %> <%= func_prefix %>__to_sklib_vector_<%= type %>(const std::vector<<%= type %>> &v)
 {
     __sklib_vector_<%= type %> __skreturn;
-    __skreturn.size = static_cast<unsigned int>(v.size());
-    __skreturn.data = (<%= lib_map_type_for(type) %> *)malloc(__skreturn.size * sizeof(<%= lib_map_type_for(type) %>));
-    int i = 0;
+    __skreturn.size<%= read_field_suffix %> = 0;
+    __skreturn.data<%= read_field_suffix %> = nullptr;
+
+    __skreturn.size<%= update_field_suffix %> = static_cast<unsigned int>(v.size());
+    __skreturn.data<%= update_field_suffix %> = (<%= lib_map_type_for(type) %> *)malloc(__skreturn.size<%= update_field_suffix %> * sizeof(<%= lib_map_type_for(type) %>));
+    unsigned int i = 0;
     for (<%= type %> d : v)
     {
-        __skreturn.data[i] = <%= func_prefix %>__to_sklib_<%= type %>(d);
+        __skreturn.data<%= update_field_suffix %>[i] = <%= func_prefix %>__to_sklib_<%= type %>(d);
         i++;
     }
     return __skreturn;
@@ -69,8 +87,8 @@ __sklib_vector_<%= type %> <%= func_prefix %>__to_sklib_vector_<%= type %>(const
 vector<<%= type %>> <%= func_prefix %>__to_vector_<%= type %>(const __sklib_vector_<%= type %> &v)
 {
     vector<<%= type %>> __skreturn;
-    for (int i = 0; i < v.size; i++) {
-        __skreturn.push_back(<%= func_prefix %>__to_<%= type %>(v.data[i]));
+    for (int i = 0; i < v.size<%= read_field_suffix %>; i++) {
+        __skreturn.push_back(<%= func_prefix %>__to_<%= type %>(v.data<%= read_field_suffix %>[i]));
     }
 <%
     # Only the adapters need to call free on return.
@@ -85,6 +103,46 @@ vector<<%= type %>> <%= func_prefix %>__to_vector_<%= type %>(const __sklib_vect
 %>
     return __skreturn;
 }
+
+<%#
+    UPDATE FUNCTIONS:
+
+    These take existing vector sklib_vector values and update them.
+%>
+
+<%
+    if is_splashkit_library?
+      # Only the library will update a __sklib__vector
+%>
+void <%= func_prefix %>__update_sklib_vector_<%= type %>(const std::vector<<%= type %>> &v, __sklib_vector_<%= type %> *__skreturn)
+{
+    __skreturn->size<%= update_field_suffix %> = static_cast<unsigned int>(v.size());
+    __skreturn->data<%= update_field_suffix %> = (<%= lib_map_type_for(type) %> *)malloc(__skreturn->size<%= update_field_suffix %> * sizeof(<%= lib_map_type_for(type) %>));
+    unsigned int i = 0;
+    for (<%= type %> d : v)
+    {
+        __skreturn->data<%= update_field_suffix %>[i] = <%= func_prefix %>__to_sklib_<%= type %>(d);
+        i++;
+    }
+}
+<%
+    else # its an adapter... only adapters will update vectors
+%>
+void <%= func_prefix %>__update_vector_<%= type %>(__sklib_vector_<%= type %> &v, std::vector<<%= type %>> &__skreturn)
+{
+    __skreturn.clear();
+
+    for (int i = 0; i < v.size<%= read_field_suffix %>; i++)
+    {
+        <%= type %> d = <%= func_prefix %>__to_<%= type %>(v.data<%= read_field_suffix %>[i]);
+        __skreturn.push_back(d);
+    }
+
+    <%= CLib::FUNC_PREFIX %>__free__sklib_vector_<%= type %>(v);
+}
+<%
+  end # end if is library
+%>
 
 <%
   end # end vectors.each

--- a/res/translators/clib/types/vectors.cpp.erb
+++ b/res/translators/clib/types/vectors.cpp.erb
@@ -114,7 +114,7 @@ vector<<%= type %>> <%= func_prefix %>__to_vector_<%= type %>(const __sklib_vect
     if is_splashkit_library?
       # Only the library will update a __sklib__vector
 %>
-void <%= func_prefix %>__update_sklib_vector_<%= type %>(const std::vector<<%= type %>> &v, __sklib_vector_<%= type %> *__skreturn)
+void <%= func_prefix %>__update_from_vector_<%= type %>(const std::vector<<%= type %>> &v, __sklib_vector_<%= type %> *__skreturn)
 {
     __skreturn->size<%= update_field_suffix %> = static_cast<unsigned int>(v.size());
     __skreturn->data<%= update_field_suffix %> = (<%= lib_map_type_for(type) %> *)malloc(__skreturn->size<%= update_field_suffix %> * sizeof(<%= lib_map_type_for(type) %>));
@@ -128,7 +128,7 @@ void <%= func_prefix %>__update_sklib_vector_<%= type %>(const std::vector<<%= t
 <%
     else # its an adapter... only adapters will update vectors
 %>
-void <%= func_prefix %>__update_vector_<%= type %>(__sklib_vector_<%= type %> &v, std::vector<<%= type %>> &__skreturn)
+void <%= func_prefix %>__update_from_vector_<%= type %>(__sklib_vector_<%= type %> &v, std::vector<<%= type %>> &__skreturn)
 {
     __skreturn.clear();
 

--- a/res/translators/clib/types/vectors.cpp.erb
+++ b/res/translators/clib/types/vectors.cpp.erb
@@ -107,7 +107,9 @@ vector<<%= type %>> <%= func_prefix %>__to_vector_<%= type %>(const __sklib_vect
 <%#
     UPDATE FUNCTIONS:
 
-    These take existing vector sklib_vector values and update them.
+    These take existing vector sklib_vector values and update them. These are
+    used with pass by ref parameters to update the sklib_vector or std::vector
+    from the other component.
 %>
 
 <%
@@ -138,6 +140,7 @@ void <%= func_prefix %>__update_from_vector_<%= type %>(__sklib_vector_<%= type 
         __skreturn.push_back(d);
     }
 
+    // Now it is copied... we need to get the library to free this!
     <%= CLib::FUNC_PREFIX %>__free__sklib_vector_<%= type %>(v);
 }
 <%

--- a/res/translators/cpp/implementation/function.cpp.erb
+++ b/res/translators/cpp/implementation/function.cpp.erb
@@ -50,6 +50,9 @@
     <%= func_call %>;
 <%#
     3. Update all non-const references.
+      - if they can be directly updated then just copy the param across as the
+        lib did the work for us!
+      - otherwise use the update function.
 %>
 <%
     non_const_refs = function[:parameters].select do | _, param_data |

--- a/res/translators/cpp/implementation/function.cpp.erb
+++ b/res/translators/cpp/implementation/function.cpp.erb
@@ -56,10 +56,17 @@
       param_data[:is_reference] && !param_data[:is_const]
     end # end select
     non_const_refs.each do | param_name, param_data |
-      adapter_fn = cpp_adapter_fn_for param_data
+      if type_can_be_directly_copied? param_data
+        adapter_fn = cpp_adapter_fn_for param_data
 %>
     <%= param_name %> = <%= adapter_fn %>(__skparam__<%= param_name %>);
 <%
+      else # cant be directly copied... use update function
+        update_fn = cpp_update_fn_for param_data
+%>
+    <%= update_fn %>(__skparam__<%= param_name %>, <%= param_name %>);
+<%
+      end # cant be directly copied...
     end # end non_const_ptrs.each
 %>
 <%#

--- a/src/main.rb
+++ b/src/main.rb
@@ -145,13 +145,13 @@ begin
       parsed = parser.parse
       if options[:verbose]
         parser.warnings.each do |msg|
-          print '[WARN]'.yellow
+          print 'translator: ', 'warning:'.yellow
           puts " #{msg}"
         end
       end
       unless parser.errors.empty?
         parser.errors.each do |msg|
-          print '[ERR]'.red
+          print 'translator: ', 'error:'.red
           puts " #{msg}"
         end
         puts 'Errors detected during parsing. Exiting.'

--- a/src/main.rb
+++ b/src/main.rb
@@ -21,7 +21,8 @@ options = {
   write_to_cache: nil,
   read_from_cache: nil,
   verbose: nil,
-  logging: nil
+  logging: nil,
+  ide: nil
 }
 
 #=== Options parse block ===
@@ -107,6 +108,12 @@ EOS
   opts.on('-l', '--logging', help) do |level|
     options[:logging] = true
   end
+  help = <<-EOS
+Format messages without colors
+EOS
+  opts.on('', '--ide', help) do |level|
+    options[:ide] = true
+  end
   opts.separator ''
   opts.separator 'Translators:'
   avaliable_translators.keys.each { |translator| opts.separator "    * #{translator}" }
@@ -145,14 +152,14 @@ begin
       parsed = parser.parse
       if options[:verbose]
         parser.warnings.each do |msg|
-          print 'translator: ', 'warning:'.yellow
-          puts " #{msg}"
+          print options[:ide] ? '' : '[WARN] '.yellow
+          puts "#{msg}"
         end
       end
       unless parser.errors.empty?
         parser.errors.each do |msg|
-          print 'translator: ', 'error:'.red
-          puts " #{msg}"
+          print options[:ide] ? 'error: ' : '[ERR] '.red
+          puts "#{msg}"
         end
         puts 'Errors detected during parsing. Exiting.'
         exit 1

--- a/src/main.rb
+++ b/src/main.rb
@@ -20,7 +20,8 @@ options = {
   validate_only: false,
   write_to_cache: nil,
   read_from_cache: nil,
-  verbose: nil
+  verbose: nil,
+  logging: nil
 }
 
 #=== Options parse block ===
@@ -100,6 +101,12 @@ EOS
   opts.on('-b', '--verbose', help) do |level|
     options[:verbose] = true
   end
+  help = <<-EOS
+Output log messages
+EOS
+  opts.on('-l', '--logging', help) do |level|
+    options[:logging] = true
+  end
   opts.separator ''
   opts.separator 'Translators:'
   avaliable_translators.keys.each { |translator| opts.separator "    * #{translator}" }
@@ -134,7 +141,7 @@ begin
     if options[:read_from_cache]
       JSON.parse(File.read(options[:read_from_cache]), symbolize_names: true)
     else
-      parser = Parser.new options[:src]
+      parser = Parser.new options[:src], options[:logging]
       parsed = parser.parse
       if options[:verbose]
         parser.warnings.each do |msg|
@@ -171,13 +178,13 @@ if options[:validate_only]
   puts 'SplashKit API documentation valid!'
 else
   options[:translators].each do |translator_class|
-    translator = translator_class.new(parsed, options[:src])
+    translator = translator_class.new(parsed, options[:src], options[:logging])
     out = translator.execute
     next unless options[:out]
     out.each do |filename, contents|
       output = "#{options[:out]}/#{translator.name}/#{filename}"
       FileUtils.mkdir_p File.dirname output
-      puts "Writing output to #{output}..."
+      puts "Writing output to #{output}..." if options[:logging]
       File.write output, contents
     end
     puts 'Output written!'

--- a/src/parser.rb
+++ b/src/parser.rb
@@ -49,6 +49,8 @@ class Parser
       out = stdout.readlines
       errs = stderr.readlines.join.gsub(/-{3,}(?:.|\n)+?-(?=\n)\n/, '').split("\n")
       errs.each do |e|
+        #fix headerdoc warning of unknown fields
+        e = e.gsub(/:Unknown field type/, ': warning: Unknown field type')
         unless e =~ /(Warning: UID.*)|(No default encoding.*)|(specifying an appropriate value.*)/
           warn "#{e}"
         end

--- a/src/parser.rb
+++ b/src/parser.rb
@@ -156,7 +156,7 @@ class Parser::HeaderFileParser
   #
   def parse_ppl(xml)
      xml.xpath('parsedparameterlist/parsedparameter').map do |p|
-      [p.xpath('name').text.to_sym, p.xpath('type').text]
+      [p.xpath('name').text.to_sym, { type: p.xpath('type').text } ]
     end.to_h
   end
 

--- a/src/parser.rb
+++ b/src/parser.rb
@@ -36,7 +36,7 @@ class Parser
   #
   def parse
     unless headerdoc_installed?
-      raise Parser::Error 'headerdoc2html is not installed!'
+      raise Parser::Error, 'headerdoc2html is not installed!'
     end
     hcfg_file = File.expand_path('../../res/headerdoc.config', __FILE__)
     # If only parsing one file then don't amend /*.h
@@ -135,11 +135,14 @@ class Parser::HeaderFileParser
   # within the hash provided using the parse_func provided
   #
   def ppl_default_to(xml, hash, ppl, parse_func = :parse_parameter_info)
+    # puts "-- In ppl default to: #{ppl}"
     ppl.each do |p_name, p_type|
+      # puts " ---- #{p_name}, #{p_type}"
       args = [xml, p_name, p_type]
       result = parse_func ? send(parse_func, *args) : {}
-      hash[p_name] = (hash[p_name] || {}).merge(result)
+      hash[p_name.to_sym] = (hash[p_name.to_sym] || {}).merge(result)
     end
+    # puts "-- RETURNING:\n#{hash}\n--\n"
     hash
   end
 
@@ -147,9 +150,49 @@ class Parser::HeaderFileParser
   # Parses HeaderDoc's parsedparameterlist (ppl) element
   #
   def parse_ppl(xml)
-    xml.xpath('parsedparameterlist/parsedparameter').map do |p|
-      [p.xpath('name').text.to_sym, p.xpath('type').text]
-    end.to_h
+    # puts "In parse ppl"
+    # puts "**************"
+    # puts xml
+    # puts "**************"
+
+    # Extract declaration details from the xml
+    decl = xml.xpath('declaration')
+    decl_types = decl.xpath('declaration_type')
+
+    # Get the type of the function
+    fn_type = decl_types[0].children.to_s
+    # types of the parameters...
+    param_types = decl_types[1..-1].map { |t| t.text }
+    # names of the parameters
+    param_names = decl.xpath('declaration_param').map { |n| n.text.to_sym }
+    # names of type parameters
+    template_types = decl.xpath('declaration_template').map { |n| n.text }
+
+    # i tracks the template_types... first may be the return type
+    i = fn_type == 'vector' ? 1 : 0
+
+    param_map = Hash[*param_names.zip(param_types).map do | n, t |
+      result ={ n => { base_type: t } }
+      if t == 'vector'
+        result[n][:type_parameter] = template_types[i]
+        i = i + 1
+      end
+
+      result
+    end.collect{|h| h.to_a}.flatten]
+
+    unless i == template_types.count
+      raise Parser::Error,
+        "Unknown template type... mapped #{i + 1} or #{param_types.count + 1} templates !"
+    end
+
+    xml.xpath('parsedparameterlist/parsedparameter').each do |p|
+      param_map[p.xpath('name').text.to_sym][:type] = p.xpath('type').text
+    end
+
+    # puts param_map
+    # puts "**************"
+    param_map
   end
 
   #
@@ -330,12 +373,17 @@ class Parser::HeaderFileParser
   #
   def parse_parameter_info(xml, param_name, ppl_type_data)
     regex = /(?:(const)\s+)?((?:unsigned\s)?\w+)\s*(?:(&amp;)|(\*)|(\[\d+\])*)?/
-    _, const, type, ref, ptr = *(ppl_type_data.match regex)
+    _, const, type, ref, ptr = *(ppl_type_data[:type].match regex)
 
     # Grab template <T> value for parameter
-    type_parameter, is_vector = *parse_vector(xml, type)
+    # type_parameter, is_vector = *parse_vector(xml, type)
     is_vector = type == 'vector'
     array = parse_array_dimensions(xml, param_name)
+
+    if is_vector && ppl_type_data[:type_parameter].nil?
+      raise Parser::Error, "Vector with unknown type parameter! #{param_name}, #{type_details}"
+    end
+
     {
       type: type,
       description: xml.xpath('desc').text,
@@ -345,7 +393,7 @@ class Parser::HeaderFileParser
       is_array: !array.empty?,
       array_dimension_sizes: array,
       is_vector: is_vector,
-      type_parameter: type_parameter
+      type_parameter: ppl_type_data[:type_parameter]
     }
   end
 
@@ -356,7 +404,10 @@ class Parser::HeaderFileParser
     name = xml.xpath('name').text
     # Need to find the matching type, this comes from
     # the parsed parameter list elements
+    # puts "Looking for #{name} in #{ppl}"
     type = ppl[name.to_sym]
+    # puts "FOUND: #{type}\n\n"
+
     if type.nil?
       raise Parser::Error,
             "Mismatched headerdoc @param '#{name}'. Check it exists in the " \
@@ -386,11 +437,16 @@ class Parser::HeaderFileParser
     # Extract template <T> value for parameter
     is_vector = type == 'vector'
     if is_vector
+      # Check if return type...
       type_parameter = xml.xpath('declaration/declaration_template').text
+      if type_parameter.nil?
+        # check if
+        raise Parser::Error, 'Unable to detect vector type!'
+      end
     end
     # Vector of vectors...
     if is_vector && type_parameter == 'vector'
-      raise Parser::Error('Vectors of vectors not yet supported!')
+      raise Parser::Error, 'Vectors of vectors not yet supported!'
     end
     [
       type_parameter,

--- a/src/parser.rb
+++ b/src/parser.rb
@@ -155,11 +155,15 @@ class Parser::HeaderFileParser
   # Parses HeaderDoc's parsedparameterlist (ppl) element
   #
   def parse_ppl(xml)
-    # puts "In parse ppl"
-    # puts "**************"
-    # puts xml
-    # puts "**************"
+     xml.xpath('parsedparameterlist/parsedparameter').map do |p|
+      [p.xpath('name').text.to_sym, p.xpath('type').text]
+    end.to_h
+  end
 
+  #
+  # Parses the parameter declaration
+  #
+  def parse_parameter_declaration(xml)
     # Extract declaration details from the xml
     decl = xml.xpath('declaration')
     decl_types = decl.xpath('declaration_type')
@@ -549,7 +553,7 @@ class Parser::HeaderFileParser
   def parse_function(xml)
     signature = parse_signature(xml)
     # Values from the <parsedparameter> elements
-    ppl = parse_ppl(xml)
+    ppl = parse_parameter_declaration(xml)
     attributes = parse_attributes(xml, ppl)
     parameters = parse_parameters(xml, ppl)
 

--- a/src/parser.rb
+++ b/src/parser.rb
@@ -49,8 +49,8 @@ class Parser
       out = stdout.readlines
       errs = stderr.readlines.join.gsub(/-{3,}(?:.|\n)+?-(?=\n)\n/, '').split("\n")
       errs.each do |e|
-        unless e =~ /Warning: UID/
-          warn "\n#{e}"
+        unless e =~ /(Warning: UID.*)|(No default encoding.*)|(specifying an appropriate value.*)/
+          warn "#{e}"
         end
       end
       exit_status = wait_thr.value.exitstatus

--- a/src/parser.rb
+++ b/src/parser.rb
@@ -308,7 +308,7 @@ class Parser::HeaderFileParser
     # by the `class`
     if self_value && ppl
       class_type = attrs[:class]
-      self_type  = ppl[self_value.to_sym]
+      self_type  = ppl[self_value.to_sym][:type]
       unless class_type == self_type
         raise Parser::RuleViolationError.new(
               'Attribute `self` must list a parameter whose type matches ' \

--- a/src/translators/abstract_translator.rb
+++ b/src/translators/abstract_translator.rb
@@ -216,5 +216,18 @@ module Translators
         type
       end
     end
+
+    #
+    # Check if the type can be copied...
+    #
+    def type_can_be_directly_copied?(type_data)
+      # puts "#{type_data}"
+      if type_data[:type] == "string"
+        raise Parser::Error, "At this stage we cant handle string passed by ref"
+      end
+
+      return ( ! type_data[:is_vector] )
+    end
+
   end
 end

--- a/src/translators/abstract_translator.rb
+++ b/src/translators/abstract_translator.rb
@@ -218,7 +218,25 @@ module Translators
     end
 
     #
-    # Check if the type can be copied...
+    # On an update of a ref parameter:
+    #
+    # Check if the type can be copied across the boundary directly. This will
+    # include the primitive types. These can just be directly assigned to the
+    # parameter in the adapter. So...
+    #
+    # - The library can directly assign a value to the parameter pointer
+    # - The adapter can just copy the value in the parameter copy to the
+    #   original parameter.
+    #
+    # But.. if this is false, it means that you cant just copy this directly
+    # across. Why? Its a dynamic array. The adapter will need to free the
+    # original dynamic array, so we need to update the original array. This will
+    # then pass back data in the `from_lib` fields of the struct, leaving the
+    # `from_app` fields untouched. So...
+    #
+    # - The library needs to use update to malloc into the `from_lib` fields.
+    # - The adapter will need to update the original vector/dynamic array. The
+    #   size may have changed, the values may have changed.
     #
     def type_can_be_directly_copied?(type_data)
       # puts "#{type_data}"

--- a/src/translators/abstract_translator.rb
+++ b/src/translators/abstract_translator.rb
@@ -15,9 +15,10 @@ module Translators
     #
     # Initializes the translator with the data and source directories provided
     #
-    def initialize(data, src)
+    def initialize(data, src, logging)
       @data = data
       @src = src
+      @logging = logging
       @direct_types = []
       @enums = @data[:enums] || @data.values.pluck(:enums).flatten
       @typealiases =
@@ -191,7 +192,7 @@ module Translators
     def read_template(name = self.name)
       # Don't know the extension, but if it's module.tpl.* then it's the primary
       # template file
-      puts "Running template #{name}..."
+      puts "Running template #{name}..." if @logging
       # Don't prepend .* unless extension is specified
       filename = name =~ /\.\w+$/ ? name : "#{name}.*"
       path = "#{translator_res_dir}/#{filename}.erb"

--- a/src/translators/clib.rb
+++ b/src/translators/clib.rb
@@ -7,8 +7,8 @@ module Translators
   class CLib < AbstractTranslator
     attr_readers :src, :header_path, :sk_root
 
-    def initialize(data, src)
-      super(data, src)
+    def initialize(data, src, logging)
+      super(data, src, logging)
       @direct_types = %w(int unsigned\ int float double char unsigned\ char)
     end
 

--- a/src/translators/clib.rb
+++ b/src/translators/clib.rb
@@ -183,6 +183,22 @@ module Translators
     end
 
     #
+    # Generate a function name to update a type
+    #
+    def sk_update_fn_for(type_data)
+      type =
+        if type_data[:type_parameter]
+          # A template
+          "from_#{type_data[:type]}_#{type_data[:type_parameter]}"
+        else
+          # Use standard type
+          raise Parser::Error, "Attempt to use invalid update function...."
+        end
+
+      "#{func_prefix}__update_#{type}"
+    end
+
+    #
     # Generate a to library adapter function name for the given type
     #
     def lib_adapter_fn_for(type_data)
@@ -193,14 +209,6 @@ module Translators
       # Replace spaces with underscores for unsigned
       type = type.tr("\s", '_')
       "#{func_prefix}__to_#{type}"
-    end
-
-    #
-    # Check
-    #
-    def type_can_be_directly_copies?(type_data)
-      # puts "#{type_data}"
-      return ( ! type_data[:is_vector]) && ( ! type_data[:type] == "string" )
     end
 
     #

--- a/src/translators/clib.rb
+++ b/src/translators/clib.rb
@@ -196,6 +196,14 @@ module Translators
     end
 
     #
+    # Check
+    #
+    def type_can_be_directly_copies?(type_data)
+      # puts "#{type_data}"
+      return ( ! type_data[:is_vector]) && ( ! type_data[:type] == "string" )
+    end
+
+    #
     # C code allocates strings and vectors on the heap. It should therefore
     # free any allocated heap memory when it is no longer required.
     #

--- a/src/translators/cpp.rb
+++ b/src/translators/cpp.rb
@@ -138,5 +138,13 @@ module Translators
       # Just use clib SK adapter -- it's the same thing
       @clib.sk_adapter_fn_for(function)
     end
+
+    #
+    # C Lib type to C++ type adapter
+    #
+    def cpp_update_fn_for(function)
+      # Just use clib SK adapter -- it's the same thing
+      @clib.sk_update_fn_for(function)
+    end
   end
 end

--- a/src/translators/cpp.rb
+++ b/src/translators/cpp.rb
@@ -5,16 +5,16 @@ module Translators
   # C++ Front-End Translator
   #
   class CPP < AbstractTranslator
-    def initialize(data, src)
-      super(data, src)
+    def initialize(data, src, logging)
+      super(data, src, logging)
       # C++ is a superset of C, so we can reuse our C implementations
-      @clib = ReusableCAdapter.new(@data, @src)
+      @clib = ReusableCAdapter.new(@data, @src, @logging)
     end
 
     def render_templates
       result = @data.map do |header_key, header_data|
         header_file_name = "#{header_key}.h"
-        header_contents  = Header.new(header_data, @src, @data)
+        header_contents  = Header.new(header_data, @src, @data, @logging)
                                  .read_template('header/module_header.h')
         [header_file_name, header_contents]
       end.to_h
@@ -29,8 +29,8 @@ module Translators
     private
 
     class Header < CPP
-      def initialize(data, src, src_data)
-        super(data, src)
+      def initialize(data, src, src_data, logging)
+        super(data, src, logging)
         @src_data = src_data
       end
 

--- a/src/translators/pascal.rb
+++ b/src/translators/pascal.rb
@@ -5,8 +5,8 @@ module Translators
   # SplashKit C Library code generator
   #
   class Pascal < AbstractTranslator
-    def initialize(data, src)
-      super(data, src)
+    def initialize(data, src, logging)
+      super(data, src, logging)
       @direct_types = {
         'int'     => 'Integer',
         'float'   => 'Single',

--- a/test/vectors/with_vector.cpp
+++ b/test/vectors/with_vector.cpp
@@ -81,4 +81,9 @@ namespace splashkit_lib
 
       nums.push_back(sum);
   }
+
+  void test_multiple_vectors(const vector<int> &ivec, const vector<string> &svec, const vector<float> &fvec)
+  {
+    
+  }
 }

--- a/test/vectors/with_vector.cpp
+++ b/test/vectors/with_vector.cpp
@@ -1,19 +1,3 @@
-//
-// Generate adapter
-// ../../translate --generate clib,cpp -i with_vector.h --output ../out
-//
-// Make static library:
-// clang++ -DBUILDING_SK_LIB -std=c++14 -c with_vector.cpp ../out/clib/sk_clib.cpp -I../clib -I../..
-// libtool -static -o libSplashKitBackend.a with_vector.o sk_clib.o
-//
-// Make dynamic library
-// clang++ -DBUILDING_SK_ADAPTER -std=c++14 -shared -g ../out/cpp/splashkit.cpp -I../out/clib -I../out/cpp -L. -lSplashKitBackend -o libSplashKit.dylib -Wl,-install_name,'@rpath/libSplashKit.dylib'
-//
-// Compile program
-// mv with_vector.h with_vector.h.old
-// clang++ -g -std=c++14 with_vector_test.cpp -L. -lSplashKit -I../out/cpp -Wl,-rpath,@loader_path
-// mv with_vector.h.old with_vector.h
-//
 #include "with_vector.h"
 
 #include <iostream>
@@ -23,7 +7,7 @@ namespace splashkit_lib
 {
   string print_string(const string &message)
   {
-    cout << message << endl;
+    cout << message;
     return message;
   }
 
@@ -47,7 +31,7 @@ namespace splashkit_lib
     {
       // cout << s << endl;
     }
-    cout << "end" << endl << endl;
+    cout << ".";
   }
 
 
@@ -84,6 +68,6 @@ namespace splashkit_lib
 
   void test_multiple_vectors(const vector<int> &ivec, const vector<string> &svec, const vector<float> &fvec)
   {
-    
+
   }
 }

--- a/test/vectors/with_vector.h
+++ b/test/vectors/with_vector.h
@@ -34,6 +34,7 @@ namespace splashkit_lib
    * the given `string` key.
    *
    * @param count The number of values
+   * 
    * @returns Values 1 to count in a vector
    */
   vector<float> get_number_list(int count);
@@ -47,7 +48,7 @@ namespace splashkit_lib
 
   /**
    * Test multiple types of vectors...
-   * 
+   *
    * @param ivec [description]
    * @param svec [description]
    * @param fvec [description]

--- a/test/vectors/with_vector.h
+++ b/test/vectors/with_vector.h
@@ -44,4 +44,13 @@ namespace splashkit_lib
    * @param nums The values passed both in and out...
    */
   void update_numbers(vector<int> &nums);
+
+  /**
+   * Test multiple types of vectors...
+   * 
+   * @param ivec [description]
+   * @param svec [description]
+   * @param fvec [description]
+   */
+  void test_multiple_vectors(const vector<int> &ivec, const vector<string> &svec, const vector<float> &fvec);
 }

--- a/test/vectors/with_vector_test.cpp
+++ b/test/vectors/with_vector_test.cpp
@@ -6,6 +6,19 @@
 
 int main()
 {
+  std:vector<int> vals;
+  vals.push_back(1);
+  vals.push_back(2);
+  vals.push_back(3);
+
+  std::cout << "Update 1,2,3" << std::endl;
+  update_numbers(vals);
+
+  for (int i : vals )
+  {
+    std::cout << i << std::endl;
+  }
+
   for (size_t i = 0; i < 100000; i++) {
     std::string str = print_string("Hello World");
   }
@@ -25,19 +38,6 @@ int main()
 
   for (size_t i = 0; i < 100000; i++) {
     print_float_list(nums);
-  }
-
-  std:vector<int> vals;
-  vals.push_back(1);
-  vals.push_back(2);
-  vals.push_back(3);
-
-  std::cout << "Update 1,2,3" << std::endl;
-  update_numbers(vals);
-
-  for (int i : nums )
-  {
-    std::cout << i << std::endl;
   }
 
   return 0;

--- a/test/vectors/with_vector_test.cpp
+++ b/test/vectors/with_vector_test.cpp
@@ -6,6 +6,8 @@
 
 int main()
 {
+  string s;
+
   std:vector<int> vals;
   vals.push_back(1);
   vals.push_back(2);
@@ -19,8 +21,11 @@ int main()
     std::cout << i << std::endl;
   }
 
+  std::cout << std::endl << "Enter string to cont.";
+  std::cin >> s;
+
   for (size_t i = 0; i < 100000; i++) {
-    std::string str = print_string("Hello World");
+    std::string str = print_string("Hello ");
   }
 
   std::vector<string> v;
@@ -32,6 +37,9 @@ int main()
 
   print_string_list(v, 10);
 
+  std::cout << std::endl << "Enter string to cont.";
+  std::cin >> s;
+
   std::vector<float> nums;
 
   nums = get_number_list(100);
@@ -39,6 +47,9 @@ int main()
   for (size_t i = 0; i < 100000; i++) {
     print_float_list(nums);
   }
+
+  std::cout << std::endl << "Enter string to cont.";
+  std::cin >> s;
 
   return 0;
 }

--- a/test/warnings/exec.sh
+++ b/test/warnings/exec.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+echo "Generate adapter"
+../../translate --verbose --generate clib,cpp -i warnings.h --output ../out

--- a/test/warnings/exec.sh
+++ b/test/warnings/exec.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 echo "Generate adapter"
-../../translate --verbose --generate clib,cpp -i warnings.h --output ../out
+../../translate --ide --verbose --generate clib,cpp -i warnings.h --output ../out

--- a/test/warnings/warnings.h
+++ b/test/warnings/warnings.h
@@ -20,3 +20,24 @@ void should_warn_about_missing_param(int param_a, int other);
  * [should_warn_about_return description]
  */
 int should_warn_about_return();
+
+/**
+ * @param happy
+ */
+void extra_param();
+
+/**
+ * @return extr
+ */
+void extra_return();
+
+/**
+ * The enum decl
+ * 
+ * @constant A  Test A
+ */
+enum Test
+{
+  A,
+  B
+}

--- a/test/warnings/warnings.h
+++ b/test/warnings/warnings.h
@@ -1,0 +1,22 @@
+/**
+ * @header Test
+ *
+ * File header...
+ */
+
+/**
+ *
+ */
+void should_warn_about_missing_param(int param);
+
+/**
+ * Also warn about overload...
+ *
+ * @param param_a Param a desc!
+ */
+void should_warn_about_missing_param(int param_a, int other);
+
+/**
+ * [should_warn_about_return description]
+ */
+int should_warn_about_return();

--- a/test/warnings/warnings.h
+++ b/test/warnings/warnings.h
@@ -33,8 +33,9 @@ void extra_return();
 
 /**
  * The enum decl
- * 
+ *
  * @constant A  Test A
+ * @fred
  */
 enum Test
 {


### PR DESCRIPTION
This fix updates vector/dynamic arrays handling.
1. When the adapter passes a dynamic array to the library it needs to pass in a c-array with size in the sklib_vector type. This is then freed by the adapter after the call.
2. When the library returns a dynamic array, the adapter will get a c-array and size in the sklib_vector type. The adapter needs to copy the values from this and then ask the library to free it.
3. When a parameter is updated, the adapter will copy the parameter and pass it across (as 1 above). When the call ends, the parameter needs to be updated (same process as 2, but into existing vector). This will then ask the library to free the value it created, and then free the value the adapter created itself.
4. When a parameter is updated in the library, it gets a copy, transfers it to a local vector, calls the actual code. It then copied the results back via the parameter (using the `from_lib` fields). This will allocate new space, which is freed after the adapter has copied the data it received.

This has been tested using the `exec.sh` script in the vectors test. The result has been checked and is functioning correctly and not leaking memory.
