### PR TITLE
Use cache to parse only partially updated source

### DIFF
--- a/res/translators/clib/sk_clib.h.erb
+++ b/res/translators/clib/sk_clib.h.erb
@@ -10,12 +10,14 @@
 %>
 #include "<%= header_path %>"
 <%
-  else # else if header does not end with .h
+  else
 %>
 <%
-    @data.each do |key, _|
+    # Default to path in data
+    @data.values.each do |header_data|
+      header_path = header_data[:path].split('/').last
 %>
-#include "<%= key %>.h"
+#include "<%= header_path %>"
 <%
     end # end data.each
 %>

--- a/res/translators/clib/types/string.cpp.erb
+++ b/res/translators/clib/types/string.cpp.erb
@@ -11,8 +11,8 @@
     7. Return the wrapped `Bar::String'
 %>
 extern "C" typedef struct {
-  char *string;
-  unsigned int size;
+    char *string;
+    unsigned int size;
 } __sklib_string;
 <%#
     The SplashKit adapter needs access to the SplashKit clib free function.
@@ -29,11 +29,11 @@ extern "C" void <%= CLib::FUNC_PREFIX %>__free__sklib_string(__sklib_string s);
     free(s.string);
 }
 __sklib_string <%= func_prefix %>__to_sklib_string(const std::string &s) {
-  __sklib_string __skreturn;
-  __skreturn.size = static_cast<unsigned int>(s.length());
-  __skreturn.string = (char *)malloc(__skreturn.size + 1);
-  strcpy(__skreturn.string, s.c_str());
-  return __skreturn;
+    __sklib_string __skreturn;
+    __skreturn.size = static_cast<unsigned int>(s.length());
+    __skreturn.string = (char *)malloc(__skreturn.size + 1);
+    strcpy(__skreturn.string, s.c_str());
+    return __skreturn;
 }
 std::string <%= func_prefix %>__to_string(const __sklib_string &s) {
     std:string result = std::string(s.string);

--- a/res/translators/cpp/header/module_header.h.erb
+++ b/res/translators/cpp/header/module_header.h.erb
@@ -14,6 +14,7 @@ header = "__#{@header_name}_h"
 
 #define <%= header %>
 
+
 <%
   dependent_headers.each do |header|
 %>
@@ -21,7 +22,6 @@ header = "__#{@header_name}_h"
 <%
   end # end dependent_headers.each
 %>
-
 #include <string>
 #include <vector>
 using std::string;
@@ -38,7 +38,6 @@ using std::vector;
 <%
   end # defines.each
 %>
-
 <%= read_template 'header/types/types' %>
 <%= read_template 'header/functions/functions' %>
 

--- a/src/config.rb
+++ b/src/config.rb
@@ -3,4 +3,6 @@ module Config
   SK_SRC_CORESDK = 'coresdk/src/coresdk'.freeze
   # Directory of generated code relative to root
   SK_TRANSLATED_OUTPUT = 'out/translated'.freeze
+  # Cache source key
+  SK_CACHE_SOURCE_KEY = :__cache_src
 end

--- a/src/main.rb
+++ b/src/main.rb
@@ -204,7 +204,7 @@ def run_parser
                       .map { |p| "#{RunOpts.src}/#{p[:path]}" }
           end
         unless to_parse.empty?
-          parsed_from_cache.merge! run_parse_on_src(to_parse)
+          parsed_from_cache.merge! run_parse_on_src(to_parse).map { |k,v| [k.to_sym, v] }.to_h
         end
         # Delete all those in parsed_from_cache that no longer exist in src
         no_longer_exists =

--- a/src/main.rb
+++ b/src/main.rb
@@ -178,17 +178,17 @@ def run_parser
       [RunOpts.src]
     else
       Dir["#{RunOpts.src}/#{SK_SRC_CORESDK}/*.h"]
-    end
+    end if RunOpts.src
   # Read cache contents if exists
   parsed =
     if RunOpts.read_from_cache
       parsed_from_cache =
         JSON.parse(File.read(RunOpts.read_from_cache), symbolize_names: true)
-      last_modified_hash = src.map do |path|
-        [path[path.index(SK_SRC_CORESDK)..-1], File.mtime(path).to_i]
-      end.to_h
       # Source also provided?
       if src
+        last_modified_hash = src.map do |path|
+          [path[path.index(SK_SRC_CORESDK)..-1], File.mtime(path).to_i]
+        end.to_h
         cache_data = parsed_from_cache.reject { |k| k == SK_CACHE_SOURCE_KEY }
                                       .values
         # Re-parse those files which have been modified after the

--- a/src/main.rb
+++ b/src/main.rb
@@ -204,17 +204,21 @@ def run_parser
     else
       run_parse_on_src(src)
     end
+  # Write to cache file
   if RunOpts.write_to_cache
     out = RunOpts.write_to_cache
     parsed[SK_CACHE_SOURCE_KEY] = RunOpts.src
     FileUtils.mkdir_p File.dirname out
     File.write out, JSON.pretty_generate(parsed)
-  elsif RunOpts.read_from_cache
+  end
+  # Read cache file means to delete the cache key
+  if RunOpts.read_from_cache
     RunOpts.src = parsed.delete(SK_CACHE_SOURCE_KEY)
     if RunOpts.src.nil?
       raise "#{SK_CACHE_SOURCE_KEY} missing from cache. Aborting."
     end
   end
+  parsed
 rescue Parser::Error
   puts $!.to_s
   exit 1

--- a/src/main.rb
+++ b/src/main.rb
@@ -227,7 +227,7 @@ end
 #
 # Run the translator, or validate only if option set
 #
-def run_translate
+def run_translate(parsed)
   if RunOpts.validate_only
     puts 'SplashKit API documentation valid!'
   else
@@ -249,5 +249,4 @@ end
 
 # Main
 parse_options
-run_parser
-run_translate
+run_translate run_parser

--- a/src/main.rb
+++ b/src/main.rb
@@ -221,9 +221,10 @@ def run_parser
   # Write to cache file
   if RunOpts.write_to_cache
     out = RunOpts.write_to_cache
-    parsed[SK_CACHE_SOURCE_KEY] = RunOpts.src
+    data = parsed
+    data[SK_CACHE_SOURCE_KEY] = RunOpts.src
     FileUtils.mkdir_p File.dirname out
-    File.write out, JSON.pretty_generate(parsed)
+    File.write out, JSON.pretty_generate(data)
   end
   # Read cache file means to delete the cache key
   if RunOpts.read_from_cache

--- a/src/main.rb
+++ b/src/main.rb
@@ -208,7 +208,7 @@ def run_parser
     out = RunOpts.write_to_cache
     parsed[SK_CACHE_SOURCE_KEY] = RunOpts.src
     FileUtils.mkdir_p File.dirname out
-    File.write out, JSON.pretty_generate(data)
+    File.write out, JSON.pretty_generate(parsed)
   elsif RunOpts.read_from_cache
     RunOpts.src = parsed.delete(SK_CACHE_SOURCE_KEY)
     if RunOpts.src.nil?

--- a/src/main.rb
+++ b/src/main.rb
@@ -221,7 +221,7 @@ def run_parser
   # Write to cache file
   if RunOpts.write_to_cache
     out = RunOpts.write_to_cache
-    data = parsed
+    data = parsed.clone
     data[SK_CACHE_SOURCE_KEY] = RunOpts.src
     FileUtils.mkdir_p File.dirname out
     File.write out, JSON.pretty_generate(data)

--- a/src/main.rb
+++ b/src/main.rb
@@ -13,124 +13,127 @@ require_relative 'translators/docs'
 # Access to config vars
 include Config
 
-# Required to run
-options = {
-  translators: [],
-  src: nil,
-  out: nil,
-  validate_only: false,
-  write_to_cache: nil,
-  read_from_cache: nil,
-  verbose: nil,
-  logging: nil,
-  ide: nil
-}
-
-#=== Options parse block ===
-opt_parser = OptionParser.new do |opts|
-  # Translators we can use
-  avaliable_translators =
-    Translators.constants
-               .select { |c| Class === Translators.const_get(c) }
-               .select { |c| ![:AbstractTranslator, :ReusableCAdapter].include? c }
-               .map { |t| [t.upcase, Translators.const_get(t)] }
-               .to_h
-  # Setup
-  help = <<-EOS
-Usage: translate --input /path/to/splashkit[/#{SK_SRC_CORESDK}/file.h]
-                [--generate GENERATOR[,GENERATOR ... ]
-                [--output /path/to/write/output/to]
-                [--validate]
-EOS
-  opts.banner = help
-  opts.separator ''
-  opts.separator 'Required:'
-  # Source file
-  help = <<-EOS
-Source header file or SplashKit CoreSDK directory
-EOS
-  opts.on('-i', '--input SOURCE', help) do |input|
-    options[:src] = File.expand_path input
-    options[:out] = "#{input}/#{SK_TRANSLATED_OUTPUT}"
+#
+# Global run options
+#
+class RunOpts
+  @tanslators = []
+  @src = nil
+  @out = nil
+  @validate_only = false
+  @write_to_cache = nil
+  @read_from_cache = nil
+  @verbose = false
+  @logging = false
+  @no_color = false
+  class << self
+    attr_accessor *(%i(
+      translators
+      src
+      out
+      validate_only
+      write_to_cache
+      read_from_cache
+      verbose
+      logging
+      no_color
+    ))
   end
-  # Generate using translator
-  help = <<-EOS
-Comma separated list of translators to run on the file(s).
-EOS
-  opts.on('-g', '--generate TRANSLATOR[,TRANSLATOR ... ]', help) do |translators|
-    parsed_translators = translators.split(',')
-    options[:translators] = parsed_translators.map do |translator|
-      translator_class = avaliable_translators[translator.upcase.to_sym]
-      if translator_class.nil?
-        raise OptionParser::InvalidOption, "#{translator} - Unknown translator #{translator}"
+end
+
+#
+# Parse options provided
+#
+def parse_options
+  opt_parser = OptionParser.new do |opts|
+    # Translators we can use
+    avaliable_translators =
+      Translators.constants
+                 .select { |c| Class === Translators.const_get(c) }
+                 .select { |c| ![:AbstractTranslator, :ReusableCAdapter].include? c }
+                 .map { |t| [t.upcase, Translators.const_get(t)] }
+                 .to_h
+    # Setup
+    help =
+      "Usage: translate --input /path/to/splashkit[/#{SK_SRC_CORESDK}/file.h]"\
+      '                [--generate GENERATOR[,GENERATOR ... ]"'\
+      '                [--output /path/to/write/output/to]"'\
+      '                [--validate]'
+    opts.banner = help
+    opts.separator ''
+    opts.separator 'Required:'
+    # Source file
+    help = 'Source header file or SplashKit CoreSDK directory'
+    opts.on('-i', '--input SOURCE', help) do |input|
+      RunOpts.src = File.expand_path input
+      RunOpts.out = "#{input}/#{SK_TRANSLATED_OUTPUT}"
+    end
+    # Generate using translator
+    help = 'Comma separated list of translators to run on the file(s).'
+    opts.on('-g', '--generate TRANSLATOR[,TRANSLATOR ... ]', help) do |translators|
+      parsed_translators = translators.split(',')
+      RunOpts.translators = parsed_translators.map do |translator|
+        translator_class = avaliable_translators[translator.upcase.to_sym]
+        if translator_class.nil?
+          raise OptionParser::InvalidOption,
+                "#{translator} - Unknown translator #{translator}"
+        end
+        translator_class
       end
-      translator_class
+    end
+    # Output file(s)
+    help = 'Directory to write output to (defaults to /path/to/splashkit/out/translated)'
+    opts.on('-o', '--output OUTPUT', help) do |out|
+      RunOpts.out = File.expand_path out
+    end
+    # Validate only (don't generate)
+    help = 'Validate HeaderDoc only to parse without translating'
+    opts.on('-v', '--validate', help) do
+      RunOpts.validate_only = true
+    end
+    # Parse and cache parsed contents to file
+    help = 'Write parsed contents to a cache file'
+    opts.on('-w', '--writecache FILE', help) do |file|
+      RunOpts.write_to_cache = File.expand_path file
+    end
+    # Read parsed contents from cache
+    help = 'Read parsed contents from a cache file'
+    opts.on('-r', '--readcache FILE', help) do |file|
+      RunOpts.read_from_cache = File.expand_path file
+    end
+    opts.separator ''
+    # Show warnings at the end of parsing
+    help = 'Log HeaderDoc warnings after parsing'
+    opts.on('-b', '--verbose', help) do
+      RunOpts.verbose = true
+    end
+    help = 'Output log messages'
+    opts.on('-l', '--logging', help) do
+      RunOpts.logging = true
+    end
+    help = 'Format messages without colors'
+    opts.on('', '--no-color', help) do
+      RunOpts.no_color = true
+    end
+    opts.separator ''
+    opts.separator 'Translators:'
+    avaliable_translators.keys.each do |translator|
+      opts.separator "* #{translator}".indent
     end
   end
-  # Output file(s)
-  help = <<-EOS
-Directory to write output to (defaults to /path/to/splashkit/out/translated)
-EOS
-  opts.on('-o', '--output OUTPUT', help) do |out|
-    options[:out] = File.expand_path out
-  end
-  # Validate only (don't generate)
-  help = <<-EOS
-Validate HeaderDoc only to parse without translating
-EOS
-  opts.on('-v', '--validate', help) do
-    options[:validate_only] = true
-  end
-  # Parse and cache parsed contents to file
-  help = <<-EOS
-Write parsed contents to a cache file
-EOS
-  opts.on('-w', '--writecache FILE', help) do |file|
-    options[:write_to_cache] = File.expand_path file
-  end
-  # Read parsed contents from cache
-  help = <<-EOS
-Read parsed contents from a cache file
-EOS
-  opts.on('-r', '--readcache FILE', help) do |file|
-    options[:read_from_cache] = File.expand_path file
-  end
-  opts.separator ''
-  # Show warnings at the end of parsing
-  help = <<-EOS
-Log HeaderDoc warnings after parsing
-EOS
-  opts.on('-b', '--verbose', help) do |level|
-    options[:verbose] = true
-  end
-  help = <<-EOS
-Output log messages
-EOS
-  opts.on('-l', '--logging', help) do |level|
-    options[:logging] = true
-  end
-  help = <<-EOS
-Format messages without colors
-EOS
-  opts.on('', '--ide', help) do |level|
-    options[:ide] = true
-  end
-  opts.separator ''
-  opts.separator 'Translators:'
-  avaliable_translators.keys.each { |translator| opts.separator "    * #{translator}" }
-end
-# Parse block
-begin
+  # Parse options block
   opt_parser.parse!
-  mandatory = options[:read_from_cache] ? [] : [:src]
+  mandatory = RunOpts.read_from_cache ? [] : [:src]
   # Add translators to mandatory if not validating
-  mandatory << :translators unless options[:validate_only]
-  missing = mandatory.select { |param| options[param].nil? }
+  mandatory << :translators unless RunOpts.validate_only
+  missing = mandatory.select do |param|
+    RunOpts.instance_variable_get("@#{param}").nil?
+  end
   # Check if read cache files exist
-  if options[:read_from_cache]
-    unless File.exist?(options[:read_from_cache])
+  if RunOpts.read_from_cache
+    unless File.exist?(RunOpts.read_from_cache)
       raise OptionParser::InvalidOption,
-            "No such cache file #{options[:read_from_cache]}"
+            "No such cache file #{RunOpts.read_from_cache}"
     end
   end
   unless missing.empty?
@@ -142,60 +145,105 @@ rescue OptionParser::InvalidOption, OptionParser::MissingArgument
   exit 1
 end
 
-#=== Try parse ===
-begin
+#
+# Parses at the src provided
+#
+def run_parse_on_src(src)
+  parser = Parser.new(src, RunOpts.logging)
+  parsed = parser.parse
+  if RunOpts.verbose
+    parser.warnings.each do |msg|
+      print RunOpts.no_color ? '' : '[WARN] '.yellow
+      puts msg
+    end
+  end
+  unless parser.errors.empty?
+    parser.errors.each do |msg|
+      print RunOpts.no_color ? 'ERROR: ' : '[ERR] '.red
+      puts msg
+    end
+    puts 'Errors detected during parsing. Exiting.'
+    exit 1
+  end
+  parsed
+end
+
+#
+# Pre-parse setup (e.g., cache handling)
+#
+def run_parser
+  # If only parsing one file then don't amend /*.h
+  src =
+    if RunOpts.src.end_with? '.h'
+      [RunOpts.src]
+    else
+      Dir["#{RunOpts.src}/#{SK_SRC_CORESDK}/*.h"]
+    end
   # Read cache contents if exists
   parsed =
-    if options[:read_from_cache]
-      JSON.parse(File.read(options[:read_from_cache]), symbolize_names: true)
+    if RunOpts.read_from_cache
+      parsed_from_cache =
+        JSON.parse(File.read(RunOpts.read_from_cache), symbolize_names: true)
+      last_modified_hash = src.map do |path|
+        [path[path.index(SK_SRC_CORESDK)..-1], File.mtime(path).to_i]
+      end.to_h
+      # Source also provided?
+      if src
+        # Re-parse those files which have been modified after the
+        # last parsed_time
+        to_parse = parsed_from_cache
+                   .reject { |k| k == SK_CACHE_SOURCE_KEY }
+                   .values
+                   .select { |p| last_modified_hash[p[:path]] > p[:parsed_at] }
+                   .map { |p| "#{RunOpts.src}/#{p[:path]}" }
+        unless to_parse.empty?
+          parsed_from_cache.merge! run_parse_on_src(to_parse)
+        end
+      end
+      parsed_from_cache
     else
-      parser = Parser.new(options[:src], options[:logging])
-      parsed = parser.parse
-      if options[:verbose]
-        parser.warnings.each do |msg|
-          print options[:ide] ? '' : '[WARN] '.yellow
-          puts msg
-        end
-      end
-      unless parser.errors.empty?
-        parser.errors.each do |msg|
-          print options[:ide] ? 'error: ' : '[ERR] '.red
-          puts msg
-        end
-        puts 'Errors detected during parsing. Exiting.'
-        exit 1
-      end
-      parsed
+      run_parse_on_src(src)
     end
-  if options[:write_to_cache]
-    out = options[:write_to_cache]
-    data = parsed.merge(__cache_src: options[:src])
+  if RunOpts.write_to_cache
+    out = RunOpts.write_to_cache
+    parsed[SK_CACHE_SOURCE_KEY] = RunOpts.src
     FileUtils.mkdir_p File.dirname out
     File.write out, JSON.pretty_generate(data)
-  elsif options[:read_from_cache]
-    options[:src] = parsed.delete(:__cache_src)
-    raise '__cache_src missing from cache. Aborting.' if options[:src].nil?
+  elsif RunOpts.read_from_cache
+    RunOpts.src = parsed.delete(SK_CACHE_SOURCE_KEY)
+    if RunOpts.src.nil?
+      raise "#{SK_CACHE_SOURCE_KEY} missing from cache. Aborting."
+    end
   end
 rescue Parser::Error
   puts $!.to_s
   exit 1
 end
 
-#=== Translate or validate ===
-if options[:validate_only]
-  puts 'SplashKit API documentation valid!'
-else
-  options[:translators].each do |translator_class|
-    translator = translator_class.new(parsed, options[:src], options[:logging])
-    out = translator.execute
-    next unless options[:out]
-    out.each do |filename, contents|
-      output = "#{options[:out]}/#{translator.name}/#{filename}"
-      FileUtils.mkdir_p File.dirname output
-      puts "Writing output to #{output}..." if options[:logging]
-      File.write output, contents
+#
+# Run the translator, or validate only if option set
+#
+def run_translate
+  if RunOpts.validate_only
+    puts 'SplashKit API documentation valid!'
+  else
+    RunOpts.translators.each do |translator_class|
+      translator = translator_class.new(parsed, RunOpts.src, RunOpts.logging)
+      out = translator.execute
+      next unless RunOpts.out
+      out.each do |filename, contents|
+        output = "#{RunOpts.out}/#{translator.name}/#{filename}"
+        FileUtils.mkdir_p File.dirname output
+        puts "Writing output to #{output}..." if RunOpts.logging
+        File.write output, contents
+      end
+      puts 'Output written!'
+      puts translator.post_execute
     end
-    puts 'Output written!'
-    puts translator.post_execute
   end
 end
+
+# Main
+parse_options
+run_parser
+run_translate

--- a/src/parser.rb
+++ b/src/parser.rb
@@ -244,12 +244,9 @@ class Parser::HeaderFileParser
     @header_attrs = parse_attributes(xml)
     group = @header_attrs[:group]
     name = xml.xpath('name').text
-    name = nil if name.end_with?('.h')
-    if group.nil? && !name.nil?
-      raise Parser::Error, "Group attribute is missing for header `#{@filename}`"
-    end
-    if name.nil?
-      raise Parser::Error, "No header tag marked on parsed file `#{@filename}`"
+    name = name[0..name.index('.h') - 1] if name.end_with?('.h') # Trim .h
+    if group.nil?
+      raise Parser::Error, "Group attribute is missing for header `#{name}.h`"
     end
     {
       name:         name,

--- a/src/parser.rb
+++ b/src/parser.rb
@@ -643,7 +643,7 @@ class Parser::HeaderFileParser
   def parse_function_pointer_typedef(xml)
     ppl = parse_ppl(xml)
     return_type = xml.xpath('declaration/declaration_type[1]').text
-    params = ppl_default_to(xml, {}, ppl) # just use PPL for this
+    params = parse_parameters(xml, ppl)
     {
       return: parse_function_return_type(xml, return_type),
       parameters: params

--- a/src/translators/cpp.rb
+++ b/src/translators/cpp.rb
@@ -66,14 +66,14 @@ module Translators
                       .pluck(:type)
           end || []
         dependent_types = (field_types + param_types + return_types)
-        @src_data.select do |_, header_data|
+        @src_data.select do |header_name, header_data|
           types_defined = header_data[:typedefs].pluck(:name) +
                           header_data[:structs].pluck(:name) +
                           header_data[:enums].pluck(:name)
           # Accepted if this header defines some of the dependent types
           # and not this header
           !(types_defined & dependent_types).empty? &&
-            header_data[:name] != @data[:name]
+            header_name != @header_name
         end.keys
       end
     end

--- a/test/warnings/warnings.h
+++ b/test/warnings/warnings.h
@@ -1,7 +1,9 @@
 /**
- * @header Test
+ * @header warning
  *
  * File header...
+ *
+ * @attribute group test
  */
 
 /**


### PR DESCRIPTION
Rather than parsing the whole coresdk, timestamps added on time of parsing will be checked against the file's last modified date.

If the file was modified after the last parse date, then the file will be re-parsed, otherwise the file will be parsed from cache.
