### PR TITLE
FIX: Fix dylib import for non-macOS platforms

### DIFF
--- a/res/translators/python/splashkit.py.erb
+++ b/res/translators/python/splashkit.py.erb
@@ -1,8 +1,19 @@
 from ctypes import *
 from enum import Enum
+from platform import system
 
-cdll.LoadLibrary("libSplashKit.dylib")
-sklib = CDLL("libsplashkit.dylib")
+if system() == 'Darwin':
+  # macOS uses .dylib extension
+  cdll.LoadLibrary("libSplashKit.dylib")
+  sklib = CDLL("libsplashkit.dylib")
+elif system() == 'Linux':
+  # Linux uses .so extension
+  cdll.LoadLibrary("libSplashKit.so")
+  sklib = CDLL("libsplashkit.so")
+else:
+  # Windows uses .dll extension:
+  cdll.LoadLibrary("libSplashKit.dll")
+  sklib = CDLL("libsplashkit.dll")
 
 <%= read_template 'ctypes/types' %>
 


### PR DESCRIPTION
Fixes https://github.com/splashkit/splashkit-windows/issues/1, and same for https://github.com/splashkit/splashkit-linux