### PR TITLE
FIX change clib loading path

### DIFF
--- a/src/translators/clib.rb
+++ b/src/translators/clib.rb
@@ -274,7 +274,7 @@ module Translators
     # Ensure name is the same as the parent class for template lookup
     #
     def name
-      'CLib'
+      'clib'
     end
   end
 end


### PR DESCRIPTION
When running translator, I had errors involving the cpp translator files loading clib translator templates, which revolved around the name being in capitals, however the the file path not. As linux has case sensitive file paths, this fails. This patch fixes the name in clib.rb to remove the capitals.