### PR TITLE
NEW Create docker file for creating an image to run translator

### DIFF
--- a/Docker_README.md
+++ b/Docker_README.md
@@ -1,0 +1,6 @@
+# To Build
+Run the following command in the translator directory
+` docker build --tag headerdoc -f Dockerfile .`
+
+# To Run
+`docker run --rm -v <absolute path to splashkit-core>:/splashkit/ headerdoc ./translate -i /splashkit/ -o /splashkit/generated -g cpp,docs,clib,python,pascal,csharp`

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM centos:centos8
+
+WORKDIR /headerdoc_build
+RUN dnf update -y \
+&& dnf install -y epel-release \
+&& dnf groupinstall -y "Development Tools" \
+&& dnf install -y \
+libxml2-devel \
+perl-HTML-Parser \
+perl-libwww-perl \
+perl-FreezeThaw \
+libxml2-devel \
+wget \
+perl-Devel-Peek \
+ruby-devel \
+rubygem-bundler \
+&& dnf clean all
+
+RUN wget https://opensource.apple.com/tarballs/headerdoc/headerdoc-8.9.5.tar.gz -qO- | tar xzf -
+WORKDIR headerdoc-8.9.5
+RUN make all || true
+RUN make realinstall
+
+COPY . /translator
+WORKDIR /translator
+RUN gem install bundler && bundle install --system
+CMD ./translate


### PR DESCRIPTION
For running translator on platforms beyond Mac OSX, you need to compile header2doc. This docker file creates an image with header2doc compiled and installed, and all the ruby environment setup to run translator.

I have also included a README section for running the docker container.