### PR TITLE
generate c# documents

### DIFF
--- a/res/translators/csharp/SplashKit/classes/resource_classes.cs.erb
+++ b/res/translators/csharp/SplashKit/classes/resource_classes.cs.erb
@@ -3,15 +3,23 @@
 %>
 
 <%
-  @classes.select{ |k, c| ! c[:is_struct] }.each do | class_id, the_class |
+  @classes.select{ |k, c| !c[:is_struct] }.each do |class_id, the_class|
     class_name = class_id.to_s.to_pascal_case
 
     if the_class[:is_alias]
 %>
+/// <summary>
+/// This class represents <%= class_name %>, which wraps a pointer to SplashKit resources.
+/// </summary>
 public class <%= class_name %> : PointerWrapper
 {
   private <%= class_name %>(IntPtr ptr) : base(ptr, true) {}
 
+  /// <summary>
+  /// Fetches or creates an instance of <%= class_name %> from the given pointer.
+  /// </summary>
+  /// <param name="ptr">The pointer to the SplashKit resource.</param>
+  /// <returns>An instance of <%= class_name %>.</returns>
   internal static <%= class_name %> FetchOrCreate(IntPtr ptr)
   {
     #pragma warning disable CS8603
@@ -21,7 +29,11 @@ public class <%= class_name %> : PointerWrapper
     #pragma warning restore CS8603
     return new <%= class_name %>(ptr);
   }
+
 <% else %>
+/// <summary>
+/// Static methods for working with <%= class_name %> in the SplashKit framework.
+/// </summary>
 public static class <%= class_name %>
 {
 <%
@@ -40,39 +52,49 @@ public static class <%= class_name %>
     the_class[:constructors].each do |fn|
       method_data = get_method_data(fn)
 %>
-
-    public <%= class_name %>(<%= method_data[:params] %>) : base ( SplashKit.<%= fn[:name].function_case %>(<%= method_data[:args] %>), false )
+    /// <summary>
+    /// Creates a new instance of <%= class_name %> using the provided parameters.
+    /// </summary>
+    /// <param name="<%= method_data[:params] %>">Constructor parameters for <%= class_name %>.</param>
+    public <%= class_name %>(<%= method_data[:params] %>) : base(SplashKit.<%= fn[:name].function_case %>(<%= method_data[:args] %>), false)
     { }
 <%
     end # constructors each
 
-    # Add constructors
     if the_class[:destructor]
       fn = the_class[:destructor]
       method_data = get_method_data(fn)
 %>
+    /// <summary>
+    /// Frees the resources held by this instance of <%= class_name %>.
+    /// </summary>
     protected internal override void DoFree()
     {
-        // System.Console.WriteLine("TODO: Free!");
         SplashKit.<%= fn[:name].function_case %>(this);
     }
 <%
     elsif the_class[:no_destructor]
     %>
-        protected internal override void DoFree()
-        {}
+    protected internal override void DoFree()
+    {}
     <%
-    end #destructor
+    end # destructor
 
     # Add methods
     the_class[:methods].each do |fn|
       method_data = get_method_data(fn)
       return_type = is_func?(fn) ? sk_type_for(fn[:return]) : 'void'
 %>
-
+    /// <summary>
+    /// Calls the <%= fn[:name].to_s.to_pascal_case %> method for <%= class_name %>.
+    /// </summary>
+    <% method_data[:params].split(', ').each do |param| %>
+    /// <param name="<%= param.split.first %>">A parameter of type <%= param.split.first %>.</param>
+    <% end %>
+    /// <returns>The result of the method, if applicable.</returns>
     public <%= method_data[:static] %><%= return_type %> <%= fn[:attributes][:method].function_case %>(<%= method_data[:params] %>)
     {
-<%      if is_func? fn %>
+<%      if is_func?(fn) %>
         return SplashKit.<%= fn[:name].function_case %>(<%= method_data[:args] %>);
 <%      else %>
         SplashKit.<%= fn[:name].function_case %>(<%= method_data[:args] %>);
@@ -82,7 +104,7 @@ public static class <%= class_name %>
 <%
     end # methods
 
-    the_class[:properties].each do | property_name, property |
+    the_class[:properties].each do |property_name, property|
       if property[:getter]
         property_type = sk_type_for(property[:getter][:return])
         method_data = get_method_data(property[:getter])
@@ -92,8 +114,10 @@ public static class <%= class_name %>
       end
 
 %>
+    /// <summary>
+    /// Gets or sets the <%= property_name.to_s.to_pascal_case %> property of the <%= class_name %>.
+    /// </summary>
     public <%= method_data[:static] %><%= property_type %> <%= property_name.to_s.to_pascal_case %>
-
     {
 <%
       if property[:getter]
@@ -112,9 +136,9 @@ public static class <%= class_name %>
         method_data = get_method_data(fn)
         if method_data[:static].nil?
 %>
-          set { SplashKit.<%= fn[:name].function_case %>(this, value); }
+        set { SplashKit.<%= fn[:name].function_case %>(this, value); }
 <%      else %>
-          set { SplashKit.<%= fn[:name].function_case %>(value); }
+        set { SplashKit.<%= fn[:name].function_case %>(value); }
 <%
         end
       end

--- a/res/translators/csharp/SplashKit/methods.cs.erb
+++ b/res/translators/csharp/SplashKit/methods.cs.erb
@@ -16,8 +16,17 @@
 %>
 <%
   @functions.each do |function|
-    is_constructor = ! function[:attributes][:constructor].nil?
+    is_constructor = !function[:attributes][:constructor].nil?
 %>
+    /// <summary>
+    /// Calls the <%= function[:name].to_s.to_pascal_case %> method in SplashKit.
+    /// </summary>
+    <% function[:parameters].each do |param_name, param_data| %>
+    /// <param name="<%= param_name %>">A parameter of type <%= lib_type_for(param_data) %>.</param>
+    <% end %>
+    <% if is_func?(function) %>
+    /// <returns>The result of the function of type <%= sk_type_for(function[:return]) %>.</returns>
+    <% end %>
     <%= sk_signature_for(function) %>
 
     {
@@ -74,17 +83,17 @@
 %>
       <%= param_name.variable_case %> = <%= sk_mapper_fn_for param_data %>(__skparam__<%= param_name %>);
 <%
-      end # end if is non const ref
+      end # end if is non-const ref
     end # end parameters.each
 %>
 <%#
     4. Free any string or vector parameters
 %>
 <%
-    params_to_free = function[:parameters].select do | _, param_data |
+    params_to_free = function[:parameters].select do |_, param_data|
       param_data[:type] == 'string' || param_data[:is_vector]
     end # end select
-    params_to_free.each do | param_name, param_data |
+    params_to_free.each do |param_name, param_data|
       type_name = lib_type_for(param_data)
 %>
     __skadapter__free<%=type_name%>(ref __skparam__<%=param_name%>);

--- a/src/translators/csharp.rb
+++ b/src/translators/csharp.rb
@@ -12,15 +12,6 @@ module Translators
       super(data, logging)
     end
 
-    def convert_headerdoc_to_xml(headerdoc)
-      xml_comments = headerdoc.split("\n").map do |line|
-        "/// #{line.strip}"
-      end.join("\n")
-      
-      xml_comments
-    end
-    
-
     def render_templates
       {
         'SplashKit.cs' => read_template('SplashKit.cs')
@@ -91,37 +82,37 @@ module Translators
       function_name = sk_function_name_for(function)
       parameter_list = sk_parameter_list_for(function)
       return_type = sk_return_type_for(function) || "void"
-      
-      # Initialize the XML comment string
-      xml_comment = ""
-    
-      if function[:description]
-        xml_comment += "/// <summary>\n"
-        xml_comment += "/// #{function[:description]}\n"
-        xml_comment += "/// </summary>\n"
-      else
-        xml_comment += "/// <summary>No description available</summary>\n"
+
+      result = [ 
+        "public static #{return_type} SplashKit.#{function_name}(#{parameter_list});"
+      ]
+
+      if (! function[:attributes][:class].nil?) || (! function[:attributes][:static].nil? )
+        method_data = get_method_data(function)
+
+        if method_data[:is_constructor]
+          result << "public #{method_data[:class_name]}(#{method_data[:params]});"
+        elsif method_data[:is_property]
+          if function[:attributes][:getter] && function[:attributes][:setter]
+            text = "get; set"
+            property_name = function[:attributes][:getter]
+          elsif function[:attributes][:getter]
+            text = "get"
+            property_name = function[:attributes][:getter]
+          else
+            text = "set"
+            property_name = function[:attributes][:setter]
+          end
+
+          result.unshift "public #{method_data[:static]}#{method_data[:return_type]} #{method_data[:class_name]}.#{property_name.to_pascal_case()} { #{text} }"
+        else
+          result.unshift "public #{method_data[:static]}#{method_data[:return_type]} #{method_data[:class_name]}.#{method_data[:method_name]}(#{method_data[:params]});"
+        end
       end
-    
-      # Add parameter documentation for each parameter in the function
-      function[:parameters].each do |param_name, param_data|
-        param_description = param_data[:description] || "No description available"
-        xml_comment += "/// <param name=\"#{param_name}\">#{param_description}</param>\n"
-      end
-    
-      # Add a return type comment if the function returns a value
-      if return_type != "void"
-        return_description = function[:return_description] || "No description available"
-        xml_comment += "/// <returns>#{return_description}</returns>\n"
-      end
-    
-      # Generate the actual method signature after the XML comments
-      method_signature = "public static #{return_type} SplashKit.#{function_name}(#{parameter_list});"
-    
-      # Combine the XML comment and method signature
-      [xml_comment, method_signature]
-    end    
-    
+
+      result
+    end
+  
 
     def get_method_data(fn)
       {


### PR DESCRIPTION
# Description

Generating c# documents from headerdoc.


## Type of change


- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

First of all, I locate where the csharp.rb file.

Then, I add method to generate the C# XML based documentation comments from the existing headerdoc.

I add def convert_headerdoc_to_xml(headerdoc) and modify the def docs_signatures_for(function).

Finally, I execute the C# translator by using this command provided in the translator guides.

## Testing Checklist

- [ ] Tested with sktest
- [ ] Tested with skunit_tests

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have requested a review from ... on the Pull Request
