### PR TITLE
Fix python library loading and issue with carriage returns

### DIFF
--- a/res/translators/python/ctypes/mappers/string.py.erb
+++ b/res/translators/python/ctypes/mappers/string.py.erb
@@ -2,7 +2,7 @@
   String mappers
 %>
 def __skadapter__to_sklib_string(s):
-    return _sklib_string(s)
+    return _sklib_string(s.replace('\r',''))
 
 sklib.__sklib__free__sklib_string.argtypes = [ _sklib_string ]
 sklib.__sklib__free__sklib_string.restype = None

--- a/res/translators/python/splashkit.py.erb
+++ b/res/translators/python/splashkit.py.erb
@@ -1,19 +1,20 @@
 from ctypes import *
 from enum import Enum
 from platform import system
+import os
 
 if system() == 'Darwin':
   # macOS uses .dylib extension
-  cdll.LoadLibrary("libSplashKit.dylib")
-  sklib = CDLL("libsplashkit.dylib")
+  cdll.LoadLibrary("/usr/local/lib/libSplashKit.dylib")
+  sklib = CDLL("/usr/local/lib/libSplashKit.dylib")
 elif system() == 'Linux':
   # Linux uses .so extension
   cdll.LoadLibrary("libSplashKit.so")
   sklib = CDLL("libSplashKit.so")
 else:
   # Windows uses .dll extension:
-  cdll.LoadLibrary("libSplashKit.dll")
-  sklib = CDLL("libsplashkit.dll")
+  cdll.LoadLibrary("C:\msys64\home\\" + os.getlogin() + "\.splashkit\lib\win64\SplashKit.dll")
+  sklib = CDLL("splashkit.dll")
 
 <%= read_template 'ctypes/types' %>
 

--- a/res/translators/python/splashkit.py.erb
+++ b/res/translators/python/splashkit.py.erb
@@ -3,44 +3,25 @@ from enum import Enum
 from platform import system
 import os
 
-# default with no path
-lib_path = ""
+search_paths = []
 
 if system() == 'Darwin':
     # macOS uses .dylib extension
-    file_extension = ".dylib"
-    file_name = "libSplashKit"
-    # find path to use -> ["global/path", "splashkit/path"]
-    paths = ["/usr/local/lib/", os.path.expanduser("~") + "/.splashkit/lib/macos/"]
-    for path in paths:
-        if (os.path.isdir(path)):
-            lib_path = path
-            break
+    search_paths = ["/usr/local/lib/libSplashKit.dylib", os.path.expanduser("~") + "/.splashkit/lib/macos/libSplashKit.dylib"]
 elif system() == 'Linux':
     # Linux uses .so extension
-    file_extension = ".so"
-    file_name = "libSplashKit"
-    # using default lib_path for now
-    # # find path to use -> ["global/path", "splashkit/path"]
-    # paths = ["/usr/local/lib/", os.path.expanduser("~") + "/.splashkit/lib/macos/"]
-    # for path in paths:
-    #     if (os.path.isdir(path)):
-    #         lib_path = path
-    #         break
+    search_paths = ["/usr/local/lib/libSplashKit.so", os.path.expanduser("~") + "/.splashkit/lib/linux/libSplashKit.so"]
 else:
-    # Windows uses .dll extension:
-    file_extension = ".dll"
-    file_name = "SplashKit"
-    # find path to use -> ["global/path", "splashkit/path"]
-    paths = ["C:/msys64/mingw64/lib/", "C:/msys64/home/" + os.getlogin() + "/.splashkit/lib/win64/"]
-    for path in paths:
-        if (os.path.isdir(path)):
-            lib_path = path
-            break
+    # Windows uses .dll extension
+    search_paths = ["C:/msys64/mingw64/lib/SplashKit.dll", "C:/msys64/home/" + os.getlogin() + "/.splashkit/lib/win64/SplashKit.dll"]
 
-# load the library
-cdll.LoadLibrary(lib_path + file_name + file_extension)
-sklib = CDLL(lib_path + file_name + file_extension)
+# find path to use -> format above is: ["global/path", ".splashkit/path"]
+for path in search_paths:
+    if (os.path.isfile(path)):
+        # load the library
+        cdll.LoadLibrary(path)
+        sklib = CDLL(path)
+        break
 
 <%= read_template 'ctypes/types' %>
 

--- a/res/translators/python/splashkit.py.erb
+++ b/res/translators/python/splashkit.py.erb
@@ -3,18 +3,44 @@ from enum import Enum
 from platform import system
 import os
 
+# default with no path
+lib_path = ""
+
 if system() == 'Darwin':
-  # macOS uses .dylib extension
-  cdll.LoadLibrary("/usr/local/lib/libSplashKit.dylib")
-  sklib = CDLL("/usr/local/lib/libSplashKit.dylib")
+    # macOS uses .dylib extension
+    file_extension = ".dylib"
+    file_name = "libSplashKit"
+    # find path to use -> ["global/path", "splashkit/path"]
+    paths = ["/usr/local/lib/", os.path.expanduser("~") + "/.splashkit/lib/macos/"]
+    for path in paths:
+        if (os.path.isdir(path)):
+            lib_path = path
+            break
 elif system() == 'Linux':
-  # Linux uses .so extension
-  cdll.LoadLibrary("libSplashKit.so")
-  sklib = CDLL("libSplashKit.so")
+    # Linux uses .so extension
+    file_extension = ".so"
+    file_name = "libSplashKit"
+    # using default lib_path for now
+    # # find path to use -> ["global/path", "splashkit/path"]
+    # paths = ["/usr/local/lib/", os.path.expanduser("~") + "/.splashkit/lib/macos/"]
+    # for path in paths:
+    #     if (os.path.isdir(path)):
+    #         lib_path = path
+    #         break
 else:
-  # Windows uses .dll extension:
-  cdll.LoadLibrary("C:\msys64\home\\" + os.getlogin() + "\.splashkit\lib\win64\SplashKit.dll")
-  sklib = CDLL("splashkit.dll")
+    # Windows uses .dll extension:
+    file_extension = ".dll"
+    file_name = "SplashKit"
+    # find path to use -> ["global/path", "splashkit/path"]
+    paths = ["C:/msys64/mingw64/lib/", "C:/msys64/home/" + os.getlogin() + "/.splashkit/lib/win64/"]
+    for path in paths:
+        if (os.path.isdir(path)):
+            lib_path = path
+            break
+
+# load the library
+cdll.LoadLibrary(lib_path + file_name + file_extension)
+sklib = CDLL(lib_path + file_name + file_extension)
 
 <%= read_template 'ctypes/types' %>
 


### PR DESCRIPTION
# Description

This pull request updates the splashkit.py file library loading to search both global and splashkit file locations, and removes carriage returns from python strings to prevent unwanted behaviour.

## Changes

1. Improved the python library loading in splashkit.py
2. Updated the python string to remove carriage returns that were causing strange behaviour with read_line (where string variables assigned with read_line would be overwritten by any strings joined after the variable when calling write_line - eg. write_line(name + "!") with a read_line input of "Olivia" would end up as "!livia"). Issue now fixed.
  Note: This issue was solved with the help of @Liquidscroll.

## How has this been tested?

Using the updated splashkit.py file generated from these changes: Ran test python program successfully (with `python3 program.py`) on Linux (Ubuntu and Manjaro), Windows (MSYS2 and WSL) and macOS.