### PR TITLE
Bug fix/csharp signature generation

### DIFF
--- a/src/translators/csharp.rb
+++ b/src/translators/csharp.rb
@@ -105,7 +105,7 @@ module Translators
           end
 
           result.unshift "public #{method_data[:static]}#{method_data[:return_type]} #{method_data[:class_name]}.#{property_name.to_pascal_case()} { #{text} }"
-        else
+        elsif method_data[:method_name]
           result.unshift "public #{method_data[:static]}#{method_data[:return_type]} #{method_data[:class_name]}.#{method_data[:method_name]}(#{method_data[:params]});"
         end
       end
@@ -116,7 +116,7 @@ module Translators
 
     def get_method_data(fn)
       {
-        method_name: fn[:name].to_s.to_pascal_case,
+        method_name: fn[:method_name].nil? ? nil : fn[:method_name].to_s.to_pascal_case,
         class_name: fn[:attributes][:class].nil? ? fn[:attributes][:static].to_pascal_case() : fn[:attributes][:class].to_pascal_case(),
         params: method_parameter_list_for(fn),
         args: method_argument_list_for(fn),


### PR DESCRIPTION
# Description
The translator was generating incorrect instance names by using :name instead of :method_name, leading to invalid or non-existent function signatures. Additionally, some functions had null values for method_name because they didnt have an instance version, meaning docs_signatures_for was generating instances that didnt exist as well as incorrect instance signatures.

# Changes
Switching to :method_name and adding a null check to skip non-existing instance functions resolved the problem.

# How has this been tested?
ran docker-compose run --rm headerdoc docs and it generated the correct api.json data with the correct instance signatures